### PR TITLE
Add static landing preview HTML

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"],
+  "rules": {
+    "react/jsx-sort-props": "off",
+    "react/react-in-jsx-scope": "off"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+.next
+out
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.env*
+.DS_Store
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,4 +1,38 @@
 # Script-Speech
 
-Voice-first scriptwriting assistant project. See [docs/voice-script-studio-development.md](docs/voice-script-studio-development.md) for the full development blueprint (v0.3) covering the glassmorphic UI direction, dual voice/text editing requirements, and the multimodal reference asset workflow.
+Voice-first scriptwriting assistant project. The repository now contains a Next.js (App Router) prototype for **Voice Script Studio**, aligning with the [development blueprint](docs/voice-script-studio-development.md).
 
+## Getting Started
+
+```bash
+npm install
+npm run dev
+```
+
+Visit `http://localhost:3000` to explore the voice-first landing experience.
+
+## Scripts
+
+- `npm run dev` — start the development server
+- `npm run build` — create a production build
+- `npm run start` — run the production build locally
+- `npm run lint` — check the codebase with ESLint
+
+## Tech Stack
+
+- Next.js 14 (App Router, TypeScript)
+- React 18
+- Tailwind CSS with custom glassmorphism tokens
+
+## Directory Layout
+
+```
+src/
+  app/            # App Router routes and layout
+  components/     # Shared UI primitives (glass cards, headers)
+  data/           # Structured content surfaced on the landing page
+```
+
+## Roadmap
+
+This prototype focuses on communicating the system vision. Upcoming work will layer in live voice capture, script editing surfaces, reference asset management, and backend orchestration described in the blueprint.

--- a/docs/preview.html
+++ b/docs/preview.html
@@ -1,0 +1,416 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Voice Script Studio — Landing Preview</title>
+    <link
+      rel="preconnect"
+      href="https://fonts.googleapis.com"
+    />
+    <link
+      rel="preconnect"
+      href="https://fonts.gstatic.com"
+      crossorigin
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: radial-gradient(120% 120% at 50% 0%, rgba(56, 189, 248, 0.35), transparent 60%),
+          radial-gradient(120% 120% at 90% 10%, rgba(129, 140, 248, 0.3), transparent 65%),
+          radial-gradient(150% 140% at 10% 10%, rgba(14, 116, 144, 0.35), transparent 60%),
+          #050816;
+        color: rgba(226, 232, 240, 0.92);
+        padding: 64px 20px 120px;
+      }
+
+      main {
+        margin: 0 auto;
+        width: min(1200px, 100%);
+        display: flex;
+        flex-direction: column;
+        gap: 120px;
+      }
+
+      .panel {
+        position: relative;
+        overflow: hidden;
+        border-radius: 32px;
+        padding: clamp(40px, 5vw, 72px);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        background: linear-gradient(145deg, rgba(15, 23, 42, 0.75), rgba(30, 41, 59, 0.45));
+        box-shadow: 0 40px 120px rgba(14, 116, 144, 0.3);
+        backdrop-filter: blur(26px);
+        -webkit-backdrop-filter: blur(26px);
+      }
+
+      .panel::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(135deg, rgba(56, 189, 248, 0.22), rgba(129, 140, 248, 0));
+        z-index: 0;
+      }
+
+      .panel > * {
+        position: relative;
+        z-index: 1;
+      }
+
+      .eyebrow {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 6px 18px;
+        border-radius: 999px;
+        border: 1px solid rgba(45, 212, 191, 0.35);
+        background: rgba(14, 116, 144, 0.25);
+        color: rgba(207, 250, 254, 0.9);
+        font-size: 0.85rem;
+        font-weight: 500;
+      }
+
+      h1 {
+        font-size: clamp(2.5rem, 5vw, 3.75rem);
+        margin: 24px 0 16px;
+        font-weight: 600;
+        letter-spacing: -0.02em;
+      }
+
+      p.lead {
+        font-size: clamp(1rem, 2vw, 1.25rem);
+        color: rgba(226, 232, 240, 0.78);
+        margin-bottom: 32px;
+        line-height: 1.7;
+      }
+
+      .button-row {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        align-items: center;
+      }
+
+      @media (min-width: 640px) {
+        .button-row {
+          flex-direction: row;
+          justify-content: center;
+        }
+      }
+
+      .cta-primary,
+      .cta-secondary {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 14px 36px;
+        font-weight: 600;
+        font-size: 1rem;
+        border-radius: 999px;
+        border: none;
+        cursor: pointer;
+        transition: transform 200ms ease;
+        text-decoration: none;
+      }
+
+      .cta-primary {
+        background: linear-gradient(135deg, rgba(56, 189, 248, 0.95), rgba(129, 140, 248, 0.95));
+        color: #020617;
+        box-shadow: 0 18px 35px rgba(34, 211, 238, 0.45);
+      }
+
+      .cta-secondary {
+        background: rgba(255, 255, 255, 0.06);
+        color: rgba(241, 245, 249, 0.92);
+        border: 1px solid rgba(255, 255, 255, 0.22);
+        backdrop-filter: blur(16px);
+      }
+
+      .cta-primary:hover,
+      .cta-secondary:hover {
+        transform: scale(1.02);
+      }
+
+      .export-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 16px;
+        margin-top: 48px;
+      }
+
+      .pill {
+        padding: 14px 0;
+        text-align: center;
+        border-radius: 20px;
+        border: 1px solid rgba(255, 255, 255, 0.16);
+        background: rgba(15, 23, 42, 0.45);
+        font-weight: 500;
+        font-size: 0.95rem;
+        color: rgba(226, 232, 240, 0.85);
+      }
+
+      section {
+        display: flex;
+        flex-direction: column;
+        gap: 36px;
+      }
+
+      .section-header h2 {
+        font-size: clamp(2rem, 4vw, 2.75rem);
+        margin: 8px 0 12px;
+        letter-spacing: -0.01em;
+      }
+
+      .section-header p {
+        margin: 0;
+        color: rgba(203, 213, 225, 0.75);
+        font-size: 1rem;
+        line-height: 1.8;
+      }
+
+      .grid-2,
+      .grid-3,
+      .grid-4 {
+        display: grid;
+        gap: 24px;
+      }
+
+      @media (min-width: 768px) {
+        .grid-2 {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+        .grid-3 {
+          grid-template-columns: repeat(3, minmax(0, 1fr));
+        }
+        .grid-4 {
+          grid-template-columns: repeat(4, minmax(0, 1fr));
+        }
+      }
+
+      .glass-card {
+        position: relative;
+        padding: 28px;
+        border-radius: 24px;
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        background: rgba(15, 23, 42, 0.55);
+        backdrop-filter: blur(24px);
+        -webkit-backdrop-filter: blur(24px);
+        box-shadow: 0 24px 60px rgba(14, 116, 144, 0.18);
+      }
+
+      .glass-card h3 {
+        margin: 0 0 12px;
+        font-size: 1.25rem;
+        letter-spacing: -0.01em;
+      }
+
+      .glass-card p {
+        margin: 0;
+        color: rgba(226, 232, 240, 0.78);
+        line-height: 1.7;
+        font-size: 1rem;
+      }
+
+      .label {
+        display: inline-block;
+        font-size: 0.8rem;
+        font-weight: 600;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: rgba(129, 140, 248, 0.8);
+        margin-bottom: 12px;
+      }
+
+      .pillars ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: grid;
+        gap: 10px;
+      }
+
+      .pillars li {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 12px;
+        align-items: start;
+        font-size: 0.95rem;
+      }
+
+      .pillars li span.dot {
+        display: inline-block;
+        width: 10px;
+        height: 10px;
+        border-radius: 999px;
+        background: linear-gradient(135deg, rgba(56, 189, 248, 0.85), rgba(99, 102, 241, 0.85));
+        margin-top: 6px;
+      }
+
+      footer.panel {
+        background: linear-gradient(145deg, rgba(30, 41, 59, 0.75), rgba(15, 23, 42, 0.55));
+      }
+
+      footer.panel::before {
+        background: linear-gradient(135deg, rgba(129, 140, 248, 0.28), rgba(56, 189, 248, 0.1));
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header class="panel">
+        <div class="eyebrow">Voice-first storytelling OS</div>
+        <h1>Interview. Iterate. Deliver production-ready scripts in hours, not weeks.</h1>
+        <p class="lead">
+          Voice Script Studio pairs real-time conversation with multimodal reference boards to plan, draft, and deliver screen-ready stories across film,
+          episodic, documentary, and commercial formats.
+        </p>
+        <div class="button-row">
+          <a class="cta-primary" href="#">Start a voice brief</a>
+          <a class="cta-secondary" href="#">Explore the studio</a>
+        </div>
+        <div class="export-grid">
+          <div class="pill">Fountain</div>
+          <div class="pill">Final Draft</div>
+          <div class="pill">DOCX</div>
+          <div class="pill">PDF</div>
+          <div class="pill">TXT</div>
+          <div class="pill">Reference boards</div>
+        </div>
+      </header>
+
+      <section>
+        <div class="section-header">
+          <div class="eyebrow">Core system</div>
+          <h2>Orchestrated agents keep writers in flow</h2>
+          <p>
+            Every tool contributes to a shared ScriptDoc backbone. Voice directives, text edits, and reference assets stay synchronized from the first beat to
+            the final export.
+          </p>
+        </div>
+        <div class="grid-2">
+          <div class="glass-card">
+            <h3>🎙️ Conversational Onboarding</h3>
+            <p>
+              Slot-filling voice interview captures script format, tone, characters, and references. Users can pause, revise, or drop supporting assets mid-flow.
+            </p>
+          </div>
+          <div class="glass-card">
+            <h3>🧠 Adaptive Drafting Pipeline</h3>
+            <p>
+              Outline, beats, and scene drafts stay in sync with inline text edits and voice corrections. Intelligent retries keep the conversation on track.
+            </p>
+          </div>
+          <div class="glass-card">
+            <h3>🖼️ Multimodal Reference Library</h3>
+            <p>
+              Attach stills, motion clips, or links to characters, locations, props, and tone boards. Drag references into scene notes and export them alongside
+              drafts.
+            </p>
+          </div>
+          <div class="glass-card">
+            <h3>📤 Production-Ready Outputs</h3>
+            <p>
+              Generate Fountain, FDX, DOCX/RTF, PDF, and TXT from a canonical ScriptDoc model. Email exports with presigned links instantly.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <div class="section-header">
+          <div class="eyebrow">Workflow</div>
+          <h2>A guided path from interview to delivery</h2>
+          <p>
+            Each stage adapts to the script type—commercial runtimes, episodic story arcs, or documentary narrative threads—all while preserving continuity and
+            references.
+          </p>
+        </div>
+        <div class="grid-4">
+          <div class="glass-card">
+            <div class="label">Onboard</div>
+            <h3>Interview &amp; Calibrate</h3>
+            <p>Voice calibration, intake questions, and reference asset capture flow into a shared project brief with autosave.</p>
+          </div>
+          <div class="glass-card">
+            <div class="label">Plan</div>
+            <h3>Outline to Beats</h3>
+            <p>Planner agent turns the confirmed brief into outlines and beat sheets that respond to voice or text revisions instantly.</p>
+          </div>
+          <div class="glass-card">
+            <div class="label">Draft</div>
+            <h3>Scenes &amp; Dialogue</h3>
+            <p>Scene writer collaborates with dialogue polisher and continuity checker to maintain tone, pacing, and character arcs.</p>
+          </div>
+          <div class="glass-card">
+            <div class="label">Deliver</div>
+            <h3>Export &amp; Share</h3>
+            <p>Queue multiple export formats, monitor job status, and send deliverables via email or secure download links.</p>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <div class="section-header">
+          <div class="eyebrow">Platform pillars</div>
+          <h2>Designed for realtime collaboration between humans and AI</h2>
+          <p>
+            Built on a Next.js front end, NestJS orchestration layer, and OpenAI realtime capabilities—backed by secure storage, accessibility features, and
+            export automation.
+          </p>
+        </div>
+        <div class="grid-3">
+          <div class="glass-card pillars">
+            <h3>Realtime Voice</h3>
+            <ul>
+              <li><span class="dot"></span><span>WebRTC-powered capture with waveform feedback</span></li>
+              <li><span class="dot"></span><span>Slot-aware prompts ask only what is missing</span></li>
+              <li><span class="dot"></span><span>Interruptions and corrections synced live</span></li>
+            </ul>
+          </div>
+          <div class="glass-card pillars">
+            <h3>Script Intelligence</h3>
+            <ul>
+              <li><span class="dot"></span><span>Canonical ScriptDoc JSON keeps every tool aligned</span></li>
+              <li><span class="dot"></span><span>Planner, beat expander, and scene writer coordinate</span></li>
+              <li><span class="dot"></span><span>Continuity guardrails flag tone or character drift</span></li>
+            </ul>
+          </div>
+          <div class="glass-card pillars">
+            <h3>Reference-Driven</h3>
+            <ul>
+              <li><span class="dot"></span><span>Upload large media with background processing</span></li>
+              <li><span class="dot"></span><span>Attach assets to characters, locations, and beats</span></li>
+              <li><span class="dot"></span><span>Drag references into notes and exports with captions</span></li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <footer class="panel">
+        <h2>Join the founding storyteller program</h2>
+        <p class="lead" style="margin-bottom: 32px;">
+          Help shape Voice Script Studio’s realtime voice and multimodal workflows. Early access members receive concierge onboarding, direct feedback channels,
+          and premium export credits.
+        </p>
+        <div class="button-row">
+          <a class="cta-primary" href="#">Request early access</a>
+          <a class="cta-secondary" href="#">View roadmap</a>
+        </div>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,11 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  experimental: {
+    serverActions: {
+      bodySizeLimit: "2mb",
+    },
+  },
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "script-speech",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.11",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.15",
+    "@types/react": "18.3.5",
+    "@types/react-dom": "18.3.0",
+    "autoprefixer": "10.4.20",
+    "eslint": "9.9.0",
+    "eslint-config-next": "14.2.11",
+    "postcss": "8.4.41",
+    "tailwindcss": "3.4.13",
+    "typescript": "5.5.4"
+  }
+}

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,18 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  @apply bg-vs-background text-white antialiased;
+  background-image: radial-gradient(circle at top left, rgba(56, 189, 248, 0.15), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(129, 140, 248, 0.2), transparent 45%);
+  min-height: 100vh;
+}
+
+a {
+  @apply text-vs-accent transition-colors hover:text-vs-accent-strong;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Voice Script Studio",
+  description:
+    "A voice-first scriptwriting environment for storytellers combining conversational capture with multimodal references.",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,116 @@
+import { coreFeatures } from "@/data/coreFeatures";
+import { platformPillars } from "@/data/platformPillars";
+import { workflowStages } from "@/data/workflowStages";
+import { GlassCard } from "@/components/GlassCard";
+import { SectionHeader } from "@/components/SectionHeader";
+
+export default function HomePage() {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-7xl flex-col gap-24 px-6 py-16 md:px-10">
+      <header className="relative overflow-hidden rounded-3xl border border-white/5 bg-vs-panel p-10 text-center shadow-glow backdrop-blur-2xl md:p-16">
+        <div className="absolute inset-0 -z-10 bg-gradient-to-br from-cyan-500/10 via-transparent to-indigo-500/20" />
+        <div className="mx-auto max-w-3xl space-y-6">
+          <span className="inline-flex items-center gap-2 rounded-full border border-cyan-400/30 bg-cyan-500/10 px-4 py-1 text-sm font-medium text-cyan-200/90">
+            Voice-first storytelling OS
+          </span>
+          <h1 className="text-balance text-4xl font-semibold tracking-tight text-white md:text-6xl">
+            Interview. Iterate. Deliver production-ready scripts in hours, not weeks.
+          </h1>
+          <p className="text-pretty text-lg text-slate-300/85 md:text-xl">
+            Voice Script Studio pairs real-time conversation with multimodal reference boards to plan, draft, and deliver screen-ready stories across film, episodic, documentary, and commercial formats.
+          </p>
+          <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
+            <button className="inline-flex items-center justify-center rounded-full bg-gradient-to-br from-cyan-400 via-cyan-300 to-indigo-400 px-8 py-3 text-base font-semibold text-slate-950 shadow-lg shadow-cyan-500/40 transition-transform hover:scale-[1.02] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-200">
+              Start a voice brief
+            </button>
+            <button className="inline-flex items-center justify-center rounded-full border border-white/20 bg-white/5 px-8 py-3 text-base font-semibold text-white/90 backdrop-blur focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60">
+              Explore the studio
+            </button>
+          </div>
+        </div>
+        <div className="mt-12 grid gap-6 sm:grid-cols-3">
+          {["Fountain", "Final Draft", "DOCX", "PDF", "TXT", "Reference boards"].map((item) => (
+            <div
+              key={item}
+              className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-medium text-slate-200/90"
+            >
+              {item}
+            </div>
+          ))}
+        </div>
+      </header>
+
+      <section className="space-y-12">
+        <SectionHeader
+          eyebrow="Core system"
+          title="Orchestrated agents keep writers in flow"
+          description="Every tool contributes to a shared ScriptDoc backbone. Voice directives, text edits, and reference assets stay synchronized from the first beat to the final export."
+        />
+        <div className="grid gap-6 md:grid-cols-2">
+          {coreFeatures.map((feature) => (
+            <GlassCard key={feature.title} title={`${feature.icon} ${feature.title}`}>
+              <p>{feature.description}</p>
+            </GlassCard>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-12">
+        <SectionHeader
+          eyebrow="Workflow"
+          title="A guided path from interview to delivery"
+          description="Each stage adapts to the script type—commercial runtimes, episodic story arcs, or documentary narrative threads—all while preserving continuity and references."
+        />
+        <div className="grid gap-6 md:grid-cols-4">
+          {workflowStages.map((stage) => (
+            <GlassCard key={stage.label} title={stage.title} subtitle={stage.label} accent="indigo">
+              <p>{stage.description}</p>
+            </GlassCard>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-12">
+        <SectionHeader
+          eyebrow="Platform pillars"
+          title="Designed for realtime collaboration between humans and AI"
+          description="Built on a Next.js front end, NestJS orchestration layer, and OpenAI realtime capabilities—backed by secure storage, accessibility features, and export automation."
+        />
+        <div className="grid gap-6 md:grid-cols-3">
+          {platformPillars.map((pillar) => (
+            <GlassCard key={pillar.title} title={pillar.title} accent="cyan">
+              <ul className="space-y-2 text-sm text-slate-200/90 md:text-base">
+                {pillar.points.map((point) => (
+                  <li key={point} className="flex items-start gap-2">
+                    <span className="mt-1 inline-block h-2.5 w-2.5 rounded-full bg-gradient-to-br from-cyan-400 to-indigo-400" />
+                    <span>{point}</span>
+                  </li>
+                ))}
+              </ul>
+            </GlassCard>
+          ))}
+        </div>
+      </section>
+
+      <footer className="relative overflow-hidden rounded-3xl border border-white/5 bg-white/5 p-10 text-center shadow-glow backdrop-blur-2xl md:p-16">
+        <div className="absolute inset-0 -z-10 bg-gradient-to-br from-indigo-500/20 via-cyan-500/10 to-transparent" />
+        <div className="mx-auto max-w-3xl space-y-6">
+          <h2 className="text-balance text-3xl font-semibold text-white md:text-5xl">
+            Join the founding storyteller program
+          </h2>
+          <p className="text-pretty text-base text-slate-300/80 md:text-lg">
+            Help shape Voice Script Studio’s realtime voice and multimodal workflows. Early access members receive concierge onboarding, direct feedback channels, and premium export credits.
+          </p>
+          <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
+            <button className="inline-flex items-center justify-center rounded-full bg-white px-8 py-3 text-base font-semibold text-slate-950 shadow-lg transition-transform hover:scale-[1.02] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70">
+              Request early access
+            </button>
+            <button className="inline-flex items-center justify-center rounded-full border border-white/20 bg-white/10 px-8 py-3 text-base font-semibold text-white/90 backdrop-blur focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60">
+              View roadmap
+            </button>
+          </div>
+        </div>
+      </footer>
+    </main>
+  );
+}

--- a/src/components/GlassCard.tsx
+++ b/src/components/GlassCard.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react";
+
+interface GlassCardProps {
+  title: string;
+  subtitle?: string;
+  children: ReactNode;
+  accent?: "cyan" | "indigo";
+}
+
+const accentClassnames: Record<NonNullable<GlassCardProps["accent"]>, string> = {
+  cyan: "from-cyan-500/40 to-cyan-400/10",
+  indigo: "from-indigo-500/40 to-indigo-400/10",
+};
+
+export function GlassCard({ title, subtitle, children, accent = "cyan" }: GlassCardProps) {
+  return (
+    <section className="rounded-3xl border border-white/10 bg-vs-panel p-8 shadow-glass backdrop-blur-xl">
+      <div
+        className={`mb-6 inline-flex flex-col gap-1 bg-gradient-to-br ${accentClassnames[accent]} bg-clip-text text-left`}
+      >
+        <h2 className="text-2xl font-semibold text-transparent md:text-3xl">{title}</h2>
+        {subtitle ? <p className="text-sm text-slate-300/90 md:text-base">{subtitle}</p> : null}
+      </div>
+      <div className="space-y-4 text-slate-200/90">{children}</div>
+    </section>
+  );
+}

--- a/src/components/SectionHeader.tsx
+++ b/src/components/SectionHeader.tsx
@@ -1,0 +1,25 @@
+interface SectionHeaderProps {
+  eyebrow?: string;
+  title: string;
+  description?: string;
+  alignment?: "left" | "center";
+}
+
+const alignmentClassnames: Record<NonNullable<SectionHeaderProps["alignment"]>, string> = {
+  left: "items-start text-left",
+  center: "items-center text-center",
+};
+
+export function SectionHeader({ eyebrow, title, description, alignment = "center" }: SectionHeaderProps) {
+  return (
+    <div className={`mx-auto flex max-w-4xl flex-col gap-4 ${alignmentClassnames[alignment]}`}>
+      {eyebrow ? (
+        <span className="text-xs font-semibold uppercase tracking-[0.3em] text-vs-accent">{eyebrow}</span>
+      ) : null}
+      <h2 className="text-balance text-3xl font-semibold text-white md:text-5xl">{title}</h2>
+      {description ? (
+        <p className="text-pretty text-base text-slate-300/85 md:text-lg">{description}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/data/coreFeatures.ts
+++ b/src/data/coreFeatures.ts
@@ -1,0 +1,26 @@
+export const coreFeatures = [
+  {
+    title: "Conversational Onboarding",
+    description:
+      "Slot-filling voice interview captures script format, tone, characters, and references. Users can pause, revise, or drop supporting assets mid-flow.",
+    icon: "🎙️",
+  },
+  {
+    title: "Adaptive Drafting Pipeline",
+    description:
+      "Outline, beats, and scene drafts stay in sync with inline text edits and voice corrections. Intelligent retries keep the conversation on track.",
+    icon: "🧠",
+  },
+  {
+    title: "Multimodal Reference Library",
+    description:
+      "Attach stills, motion clips, or links to characters, locations, props, and tone boards. Drag references into scene notes and export them alongside drafts.",
+    icon: "🖼️",
+  },
+  {
+    title: "Production-Ready Outputs",
+    description:
+      "Generate Fountain, FDX, DOCX/RTF, PDF, and TXT from a canonical ScriptDoc model. Email exports with presigned links instantly.",
+    icon: "📤",
+  },
+];

--- a/src/data/platformPillars.ts
+++ b/src/data/platformPillars.ts
@@ -1,0 +1,26 @@
+export const platformPillars = [
+  {
+    title: "Realtime Voice",
+    points: [
+      "WebRTC-powered capture with waveform feedback",
+      "Slot-aware prompts ask only what is missing",
+      "Interruptions and corrections synced live",
+    ],
+  },
+  {
+    title: "Script Intelligence",
+    points: [
+      "Canonical ScriptDoc JSON keeps every tool aligned",
+      "Planner, beat expander, and scene writer coordinate",
+      "Continuity guardrails flag tone or character drift",
+    ],
+  },
+  {
+    title: "Reference-Driven",
+    points: [
+      "Upload large media with background processing",
+      "Attach assets to characters, locations, and beats",
+      "Drag references into notes and exports with captions",
+    ],
+  },
+];

--- a/src/data/workflowStages.ts
+++ b/src/data/workflowStages.ts
@@ -1,0 +1,26 @@
+export const workflowStages = [
+  {
+    label: "Onboard",
+    title: "Interview & Calibrate",
+    description:
+      "Voice calibration, intake questions, and reference asset capture flow into a shared project brief with autosave.",
+  },
+  {
+    label: "Plan",
+    title: "Outline to Beats",
+    description:
+      "Planner agent turns the confirmed brief into outlines and beat sheets that respond to voice or text revisions instantly.",
+  },
+  {
+    label: "Draft",
+    title: "Scenes & Dialogue",
+    description:
+      "Scene writer collaborates with dialogue polisher and continuity checker to maintain tone, pacing, and character arcs.",
+  },
+  {
+    label: "Deliver",
+    title: "Export & Share",
+    description:
+      "Queue multiple export formats, monitor job status, and send deliverables via email or secure download links.",
+  },
+];

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,29 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        "vs-background": "#020617",
+        "vs-panel": "rgba(15, 23, 42, 0.6)",
+        "vs-accent": "#38bdf8",
+        "vs-accent-strong": "#818cf8"
+      },
+      backdropBlur: {
+        xs: "2px"
+      },
+      boxShadow: {
+        glass: "0 20px 45px -25px rgba(56, 189, 248, 0.45)",
+        glow: "0 0 50px rgba(129, 140, 248, 0.35)"
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a standalone HTML preview that mirrors the Voice Script Studio landing page
- style the preview with glassmorphic gradients and responsive card grids for core sections
- include CTA buttons and export format pills so stakeholders can review the experience without running Next.js

## Testing
- not run (HTML preview file only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e8dd5544483228425681020e695f3)