### PR TITLE
Connect Script Speech UI to backend content APIs

### DIFF
--- a/docs/script-speech-preview.html
+++ b/docs/script-speech-preview.html
@@ -1,0 +1,521 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Script Speech — Experience Preview</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        background: #050505;
+        color: rgba(244, 244, 245, 0.9);
+        min-height: 100vh;
+        padding: 72px 20px 120px;
+        background-image:
+          radial-gradient(140% 120% at 10% 0%, rgba(82, 82, 91, 0.42), transparent 65%),
+          radial-gradient(120% 100% at 90% 10%, rgba(24, 24, 27, 0.75), transparent 70%),
+          linear-gradient(160deg, rgba(9, 9, 11, 0.92), rgba(15, 15, 15, 0.92));
+      }
+
+      main {
+        width: min(1120px, 100%);
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 120px;
+      }
+
+      .hero {
+        position: relative;
+        border-radius: 48px;
+        padding: clamp(48px, 8vw, 96px);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        background: radial-gradient(120% 160% at 0% 0%, rgba(63, 63, 70, 0.3), transparent 65%),
+          linear-gradient(145deg, rgba(24, 24, 27, 0.9), rgba(39, 39, 42, 0.45));
+        backdrop-filter: blur(24px);
+        -webkit-backdrop-filter: blur(24px);
+        box-shadow: 0 50px 120px rgba(0, 0, 0, 0.45);
+        overflow: hidden;
+      }
+
+      .hero::after {
+        content: "";
+        position: absolute;
+        inset: -50% -20% auto 45%;
+        height: 180%;
+        border-radius: 999px;
+        background: linear-gradient(90deg, rgba(250, 250, 250, 0.08), transparent 65%);
+        transform: rotate(12deg);
+      }
+
+      .hero-tag {
+        display: inline-flex;
+        align-items: center;
+        padding: 10px 22px;
+        font-size: 0.75rem;
+        letter-spacing: 0.35em;
+        text-transform: uppercase;
+        border-radius: 999px;
+        border: 1px solid rgba(228, 228, 231, 0.15);
+        color: rgba(244, 244, 245, 0.7);
+        background: rgba(63, 63, 70, 0.2);
+      }
+
+      h1 {
+        margin: 32px 0 16px;
+        font-size: clamp(2.75rem, 5vw, 4.25rem);
+        letter-spacing: -0.03em;
+        color: #fff;
+      }
+
+      .anim-wrapper {
+        font-size: clamp(1.1rem, 2.6vw, 1.5rem);
+        font-weight: 500;
+        color: rgba(244, 244, 245, 0.75);
+        min-height: 2.25rem;
+      }
+
+      .animated-text {
+        display: inline-block;
+        position: relative;
+        overflow: hidden;
+      }
+
+      .animated-text span {
+        display: block;
+        animation: headline 16s infinite;
+        white-space: nowrap;
+      }
+
+      @keyframes headline {
+        0%, 20% {
+          transform: translateY(0%);
+        }
+        25%, 45% {
+          transform: translateY(-100%);
+        }
+        50%, 70% {
+          transform: translateY(-200%);
+        }
+        75%, 95% {
+          transform: translateY(-300%);
+        }
+        100% {
+          transform: translateY(0%);
+        }
+      }
+
+      .hero p {
+        margin: 28px 0 40px;
+        font-size: clamp(1rem, 2.4vw, 1.2rem);
+        line-height: 1.8;
+        color: rgba(212, 212, 216, 0.78);
+        max-width: 620px;
+      }
+
+      .cta-row {
+        display: flex;
+        flex-direction: column;
+        gap: 14px;
+        align-items: flex-start;
+      }
+
+      @media (min-width: 640px) {
+        .cta-row {
+          flex-direction: row;
+        }
+      }
+
+      .cta {
+        text-decoration: none;
+        font-weight: 600;
+        font-size: 0.95rem;
+        border-radius: 999px;
+        padding: 14px 32px;
+        transition: transform 220ms ease, border-color 220ms ease;
+      }
+
+      .cta.primary {
+        background: rgba(250, 250, 250, 0.92);
+        color: #09090b;
+        border: 1px solid rgba(250, 250, 250, 0.85);
+      }
+
+      .cta.secondary {
+        border: 1px solid rgba(228, 228, 231, 0.25);
+        color: rgba(244, 244, 245, 0.85);
+        background: rgba(63, 63, 70, 0.2);
+      }
+
+      .cta.ghost {
+        border: 1px solid rgba(82, 82, 91, 0.35);
+        color: rgba(228, 228, 231, 0.65);
+        background: rgba(39, 39, 42, 0.2);
+      }
+
+      .cta:hover {
+        transform: translateY(-4px);
+      }
+
+      section {
+        display: flex;
+        flex-direction: column;
+        gap: 36px;
+      }
+
+      h2 {
+        font-size: clamp(2.2rem, 4vw, 3rem);
+        letter-spacing: -0.02em;
+        margin: 0;
+      }
+
+      .section-sub {
+        color: rgba(161, 161, 170, 0.85);
+        font-size: 1rem;
+        line-height: 1.8;
+        margin: 0;
+      }
+
+      .split {
+        display: grid;
+        gap: 40px;
+      }
+
+      @media (min-width: 900px) {
+        .split {
+          grid-template-columns: 1.1fr 0.9fr;
+        }
+      }
+
+      .vignette-card {
+        border-radius: 28px;
+        padding: 28px;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        background: rgba(24, 24, 27, 0.55);
+        transition: border-color 200ms ease, transform 200ms ease;
+      }
+
+      .vignette-card:hover {
+        border-color: rgba(250, 250, 250, 0.35);
+        transform: translateY(-6px);
+      }
+
+      .vignette-title {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-size: 1.05rem;
+        font-weight: 600;
+      }
+
+      .vignette-title a {
+        text-decoration: none;
+        color: rgba(161, 161, 170, 0.7);
+      }
+
+      .vignette-title a:hover {
+        color: #fafafa;
+      }
+
+      .vignette-copy {
+        margin-top: 16px;
+        font-size: 0.95rem;
+        line-height: 1.8;
+        color: rgba(212, 212, 216, 0.75);
+      }
+
+      .cadence-grid {
+        display: grid;
+        gap: 24px;
+      }
+
+      @media (min-width: 900px) {
+        .cadence-grid {
+          grid-template-columns: repeat(3, minmax(0, 1fr));
+        }
+      }
+
+      .cadence-step {
+        border-radius: 28px;
+        padding: 28px;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        background: rgba(17, 17, 17, 0.7);
+        transition: transform 220ms ease;
+      }
+
+      .cadence-step:hover {
+        transform: translateY(-8px);
+      }
+
+      .cadence-step p {
+        margin: 0;
+        line-height: 1.7;
+      }
+
+      .step-label {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.32em;
+        color: rgba(120, 113, 198, 0.75);
+      }
+
+      .step-body {
+        margin-top: 18px;
+        color: rgba(212, 212, 216, 0.75);
+      }
+
+      .step-link {
+        display: inline-flex;
+        margin-top: 24px;
+        font-size: 0.85rem;
+        text-decoration: none;
+        color: rgba(161, 161, 170, 0.75);
+      }
+
+      .step-link:hover {
+        color: #fafafa;
+      }
+
+      .cta-panel {
+        text-align: center;
+        padding: clamp(48px, 7vw, 72px);
+        border-radius: 44px;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        background: linear-gradient(135deg, rgba(63, 63, 70, 0.35), rgba(24, 24, 27, 0.9));
+        box-shadow: 0 30px 120px rgba(24, 24, 27, 0.5);
+      }
+
+      .cta-panel p {
+        margin: 0;
+        color: rgba(212, 212, 216, 0.75);
+        line-height: 1.7;
+      }
+
+      .cta-panel .eyebrow {
+        border-color: rgba(82, 82, 91, 0.45);
+        background: rgba(63, 63, 70, 0.25);
+        color: rgba(161, 161, 170, 0.9);
+      }
+
+      footer {
+        border-top: 1px solid rgba(39, 39, 42, 0.85);
+        padding-top: 36px;
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+      }
+
+      footer .foot-header {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        text-transform: uppercase;
+        font-size: 0.72rem;
+        letter-spacing: 0.32em;
+        color: rgba(113, 113, 122, 0.85);
+      }
+
+      @media (min-width: 700px) {
+        footer .foot-header {
+          flex-direction: row;
+          justify-content: space-between;
+          align-items: center;
+        }
+      }
+
+      footer a {
+        text-decoration: none;
+        color: rgba(244, 244, 245, 0.7);
+      }
+
+      footer a:hover {
+        color: #fafafa;
+      }
+
+      .footnotes {
+        display: grid;
+        gap: 14px;
+      }
+
+      @media (min-width: 780px) {
+        .footnotes {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      .footnote-item {
+        border-radius: 24px;
+        border: 1px solid rgba(255, 255, 255, 0.06);
+        background: rgba(24, 24, 27, 0.55);
+        padding: 18px 22px;
+        display: flex;
+        gap: 16px;
+        align-items: baseline;
+      }
+
+      .footnote-index {
+        font-weight: 600;
+        color: rgba(212, 212, 216, 0.6);
+        font-size: 0.85rem;
+      }
+
+      .footnote-title {
+        font-size: 0.95rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header class="hero">
+        <div class="hero-tag">Script Speech</div>
+        <h1>The voice-led story studio for directors who think out loud.</h1>
+        <div class="anim-wrapper">
+          <div class="animated-text" aria-live="polite">
+            <span>
+              Draft cinema-ready stories by speaking<br />
+              Sketch acts, beats, and shots without friction<br />
+              Deliver production files the same day<br />
+              Keep the landing page nothing but signal
+            </span>
+          </div>
+        </div>
+        <p>
+          Script Speech keeps the landing page focused on the mood: low light, confident lines, and zero clutter.
+          Speak your vision and the canvas adapts without compromising precision.
+        </p>
+        <div class="cta-row">
+          <a class="cta primary" href="#canvas">Enter the studio</a>
+          <a class="cta secondary" href="#faq">Study the system</a>
+          <a class="cta ghost" href="#preview">Share the preview</a>
+        </div>
+      </header>
+
+      <section class="split" id="canvas">
+        <article>
+          <h2>A stripped-back control room where every surface listens.</h2>
+          <p class="section-sub">
+            Direct the session with voice and keep typing in reach for surgical edits. The interface is monochrome on
+            purpose—your story, waveforms, and references are the only elements in motion. Scene boards and exports remain
+            tucked away until you summon them<sup>3</sup>.
+          </p>
+          <p class="section-sub">
+            The landing page is nothing but welcome and invitation. Production controls live beyond the fold so prospects
+            catch the vibe first and dive into details later.
+          </p>
+        </article>
+        <aside class="vignette-grid">
+          <div class="vignette-card">
+            <div class="vignette-title">
+              <span>Voice directs the room</span>
+              <a href="#faq-1">1</a>
+            </div>
+            <p class="vignette-copy">
+              Speak the brief, calibrate tone, and watch the story spine assemble itself. Text is always there when you
+              need to fine-tune.
+            </p>
+          </div>
+          <div class="vignette-card">
+            <div class="vignette-title">
+              <span>Canvas stays in sync</span>
+              <a href="#faq-2">2</a>
+            </div>
+            <p class="vignette-copy">
+              Outline, beat grid, and script view are rendered from one ScriptDoc core so every revision lands everywhere
+              at once.
+            </p>
+          </div>
+          <div class="vignette-card">
+            <div class="vignette-title">
+              <span>References travel with you</span>
+              <a href="#faq-3">3</a>
+            </div>
+            <p class="vignette-copy">
+              Boards, clips, and research snippets follow each scene and export with your package. Nothing gets stranded in
+              a drive.
+            </p>
+          </div>
+        </aside>
+      </section>
+
+      <section id="preview">
+        <h2>How a session flows once you log in</h2>
+        <div class="cadence-grid">
+          <div class="cadence-step">
+            <p class="step-label">1. Tune the signal</p>
+            <p class="step-body">
+              A minimalist intake checks format, pacing, and references while your waveform shows the room is listening.
+            </p>
+            <a class="step-link" href="#faq-1">Learn more ↗</a>
+          </div>
+          <div class="cadence-step">
+            <p class="step-label">2. Move the pieces</p>
+            <p class="step-body">
+              Outline and beat editors adapt instantly to voice or keyboard adjustments so structure never lags behind.
+            </p>
+            <a class="step-link" href="#faq-2">Learn more ↗</a>
+          </div>
+          <div class="cadence-step">
+            <p class="step-label">3. Deliver with certainty</p>
+            <p class="step-body">
+              Queue exports, share secure links, and walk into your next session with production-ready files in hand.
+            </p>
+            <a class="step-link" href="#faq-4">Learn more ↗</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="cta-panel">
+        <div class="hero-tag">Early collaborator program</div>
+        <h2>Help us tune Script Speech for productions that move fast.</h2>
+        <p>
+          Founding teams receive guided onboarding, access to the redesigned studio canvas, and direct lines to the crew
+          building the experience.
+        </p>
+        <div class="cta-row" style="justify-content: center; margin-top: 32px">
+          <a class="cta primary" href="#canvas">Preview the canvas</a>
+          <a class="cta secondary" href="mailto:hello@scriptspeech.com">Request access</a>
+        </div>
+      </section>
+
+      <footer id="faq">
+        <div class="foot-header">
+          <span>Feature footnotes</span>
+          <a href="https://example.com/faq">View the FAQ dossier</a>
+        </div>
+        <div class="footnotes">
+          <div class="footnote-item" id="faq-1">
+            <span class="footnote-index">[1]</span>
+            <span class="footnote-title">Voice-directed storyboarding engine</span>
+          </div>
+          <div class="footnote-item" id="faq-2">
+            <span class="footnote-index">[2]</span>
+            <span class="footnote-title">Canvas-wide ScriptDoc sync</span>
+          </div>
+          <div class="footnote-item" id="faq-3">
+            <span class="footnote-index">[3]</span>
+            <span class="footnote-title">Reference locker that travels</span>
+          </div>
+          <div class="footnote-item" id="faq-4">
+            <span class="footnote-index">[4]</span>
+            <span class="footnote-title">Export control room with instant delivery</span>
+          </div>
+        </div>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@types/react": "18.3.5",
     "@types/react-dom": "18.3.0",
     "autoprefixer": "10.4.20",
-    "eslint": "9.9.0",
+    "eslint": "8.57.0",
     "eslint-config-next": "14.2.11",
     "postcss": "8.4.41",
     "tailwindcss": "3.4.13",

--- a/src/app/api/faq/route.ts
+++ b/src/app/api/faq/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+
+import { getFaqContent } from "@/lib/siteData";
+
+export async function GET() {
+  const content = await getFaqContent();
+
+  return NextResponse.json(content);
+}

--- a/src/app/api/landing/route.ts
+++ b/src/app/api/landing/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+
+import { getLandingContent } from "@/lib/siteData";
+
+export async function GET() {
+  const content = await getLandingContent();
+
+  return NextResponse.json(content);
+}

--- a/src/app/api/request-access/route.ts
+++ b/src/app/api/request-access/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+
+import {
+  createAccessRequest,
+  listAccessRequests,
+} from "@/lib/accessRequests";
+
+export async function GET() {
+  const requests = await listAccessRequests();
+  return NextResponse.json({ requests });
+}
+
+export async function POST(request: Request) {
+  try {
+    const payload = await request.json();
+
+    const record = await createAccessRequest({
+      email: payload?.email ?? "",
+      message: payload?.message,
+    });
+
+    return NextResponse.json({ success: true, request: record }, { status: 201 });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unable to process your request right now.";
+
+    return NextResponse.json({ success: false, message }, { status: 400 });
+  }
+}

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -1,0 +1,90 @@
+import Link from "next/link";
+
+import { GlassCard } from "@/components/GlassCard";
+import { SectionHeader } from "@/components/SectionHeader";
+import { fetchFaqContent } from "@/lib/http";
+
+export const dynamic = "force-dynamic";
+
+export default async function FAQPage() {
+  const faq = await fetchFaqContent();
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-20 px-6 py-16 md:px-10">
+      <header className="space-y-10">
+        <SectionHeader
+          alignment="left"
+          eyebrow="FAQ dossier"
+          title="Details that stay off the landing page"
+          description="Script Speech keeps the hero moment quiet and confident. This dossier captures the mechanics and safeguards once you are inside the workspace."
+        />
+        <p className="max-w-2xl text-sm text-zinc-400 md:text-base">
+          Looking for something specific? Email us at
+          <Link href="mailto:hello@scriptspeech.com" className="ml-2 underline underline-offset-4">
+            hello@scriptspeech.com
+          </Link>
+          .
+        </p>
+      </header>
+
+      <section className="space-y-10">
+        <SectionHeader
+          alignment="left"
+          eyebrow="Core system"
+          title="What powers each session?"
+          description="Four feature pillars handle intake, drafting, reference management, and delivery without overwhelming the interface."
+        />
+        <div className="grid gap-6 md:grid-cols-2">
+          {faq.coreFeatures.map((feature) => (
+            <GlassCard key={feature.slug} id={feature.slug} title={feature.title}>
+              <p>{feature.description}</p>
+            </GlassCard>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-10">
+        <SectionHeader
+          alignment="left"
+          eyebrow="Workflow"
+          title="How does the flow feel after login?"
+          description="The studio canvas opens to a voice-ready control room. These stages surface progressively so the workspace stays calm."
+        />
+        <div className="grid gap-6 md:grid-cols-2">
+          {faq.workflowStages.map((stage) => (
+            <GlassCard key={stage.slug} id={stage.slug} title={stage.title} subtitle={stage.label} accent="dim">
+              <p>{stage.description}</p>
+            </GlassCard>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-10">
+        <SectionHeader
+          alignment="left"
+          eyebrow="Platform"
+          title="Under the hood"
+          description="Script Speech combines realtime voice processing, orchestrated AI agents, and reference management."
+        />
+        <div className="grid gap-6 md:grid-cols-3">
+          {faq.platformPillars.map((pillar) => (
+            <GlassCard key={pillar.slug} id={pillar.slug} title={pillar.title}>
+              <ul className="space-y-2 text-sm text-zinc-300/90 md:text-base">
+                {pillar.points.map((point) => (
+                  <li key={point}>{point}</li>
+                ))}
+              </ul>
+            </GlassCard>
+          ))}
+        </div>
+      </section>
+
+      <footer className="space-y-6 border-t border-white/10 pt-10 text-sm text-zinc-500">
+        <p className="text-xs uppercase tracking-[0.35em] text-zinc-600">Back to top</p>
+        <Link href="/" className="inline-flex text-sm text-white hover:text-vs-accent-strong">
+          Return to the landing page ↗
+        </Link>
+      </footer>
+    </main>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,11 +8,32 @@
 
 body {
   @apply bg-vs-background text-white antialiased;
-  background-image: radial-gradient(circle at top left, rgba(56, 189, 248, 0.15), transparent 55%),
-    radial-gradient(circle at bottom right, rgba(129, 140, 248, 0.2), transparent 45%);
+  background-image: radial-gradient(circle at top left, rgba(255, 255, 255, 0.08), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(39, 39, 42, 0.9), transparent 45%);
   min-height: 100vh;
 }
 
 a {
   @apply text-vs-accent transition-colors hover:text-vs-accent-strong;
+}
+
+@layer utilities {
+  .text-gradient-sheen {
+    background: linear-gradient(120deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.4));
+    background-clip: text;
+    color: transparent;
+  }
+
+  .grain-overlay {
+    position: relative;
+  }
+
+  .grain-overlay::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.2' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23n)' opacity='0.08'/%3E%3C/svg%3E");
+    mix-blend-mode: soft-light;
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,9 +3,9 @@ import type { ReactNode } from "react";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "Voice Script Studio",
+  title: "Script Speech",
   description:
-    "A voice-first scriptwriting environment for storytellers combining conversational capture with multimodal references.",
+    "Script Speech is a voice-forward story studio with a reimagined canvas for writers and directors to think out loud.",
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,115 +1,151 @@
-import { coreFeatures } from "@/data/coreFeatures";
-import { platformPillars } from "@/data/platformPillars";
-import { workflowStages } from "@/data/workflowStages";
-import { GlassCard } from "@/components/GlassCard";
-import { SectionHeader } from "@/components/SectionHeader";
+import Link from "next/link";
 
-export default function HomePage() {
+import { AccessRequestForm } from "@/components/AccessRequestForm";
+import { AnimatedHeadline } from "@/components/AnimatedHeadline";
+import { fetchFaqContent, fetchLandingContent } from "@/lib/http";
+
+export const dynamic = "force-dynamic";
+
+export default async function HomePage() {
+  const [landing, faq] = await Promise.all([fetchLandingContent(), fetchFaqContent()]);
+
+  const footnotes = faq.coreFeatures.map((feature, index) => ({
+    number: index + 1,
+    title: feature.title,
+    href: `/faq#${feature.slug}`,
+  }));
+
   return (
-    <main className="mx-auto flex min-h-screen max-w-7xl flex-col gap-24 px-6 py-16 md:px-10">
-      <header className="relative overflow-hidden rounded-3xl border border-white/5 bg-vs-panel p-10 text-center shadow-glow backdrop-blur-2xl md:p-16">
-        <div className="absolute inset-0 -z-10 bg-gradient-to-br from-cyan-500/10 via-transparent to-indigo-500/20" />
-        <div className="mx-auto max-w-3xl space-y-6">
-          <span className="inline-flex items-center gap-2 rounded-full border border-cyan-400/30 bg-cyan-500/10 px-4 py-1 text-sm font-medium text-cyan-200/90">
-            Voice-first storytelling OS
-          </span>
-          <h1 className="text-balance text-4xl font-semibold tracking-tight text-white md:text-6xl">
-            Interview. Iterate. Deliver production-ready scripts in hours, not weeks.
-          </h1>
-          <p className="text-pretty text-lg text-slate-300/85 md:text-xl">
-            Voice Script Studio pairs real-time conversation with multimodal reference boards to plan, draft, and deliver screen-ready stories across film, episodic, documentary, and commercial formats.
-          </p>
-          <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
-            <button className="inline-flex items-center justify-center rounded-full bg-gradient-to-br from-cyan-400 via-cyan-300 to-indigo-400 px-8 py-3 text-base font-semibold text-slate-950 shadow-lg shadow-cyan-500/40 transition-transform hover:scale-[1.02] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-200">
-              Start a voice brief
-            </button>
-            <button className="inline-flex items-center justify-center rounded-full border border-white/20 bg-white/5 px-8 py-3 text-base font-semibold text-white/90 backdrop-blur focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60">
-              Explore the studio
-            </button>
+    <main className="mx-auto flex min-h-screen max-w-6xl flex-col gap-24 px-6 py-16 md:px-10">
+      <header className="grain-overlay relative overflow-hidden rounded-[3rem] border border-white/10 bg-vs-panel px-10 py-16 shadow-glow backdrop-blur-2xl md:px-16 md:py-24">
+        <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.08),_transparent_55%)]" />
+        <div className="flex flex-col gap-8">
+          <div className="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/5 px-5 py-2 text-xs font-medium uppercase tracking-[0.35em] text-zinc-300">
+            Script Speech
           </div>
-        </div>
-        <div className="mt-12 grid gap-6 sm:grid-cols-3">
-          {["Fountain", "Final Draft", "DOCX", "PDF", "TXT", "Reference boards"].map((item) => (
-            <div
-              key={item}
-              className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-medium text-slate-200/90"
+          <div className="max-w-3xl space-y-6">
+            <h1 className="text-balance text-4xl font-semibold tracking-tight text-white md:text-6xl">
+              {landing.hero.title}
+            </h1>
+            <AnimatedHeadline phrases={landing.hero.phrases} />
+            <p className="text-pretty text-lg text-zinc-300/90 md:text-xl">{landing.hero.description}</p>
+          </div>
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <Link
+              href="/studio"
+              className="inline-flex items-center justify-center rounded-full border border-white/20 bg-white/90 px-8 py-3 text-base font-semibold text-zinc-950 transition-transform duration-300 hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60"
             >
-              {item}
-            </div>
-          ))}
+              Enter the studio
+            </Link>
+            <Link
+              href="/faq"
+              className="inline-flex items-center justify-center rounded-full border border-white/20 bg-white/5 px-8 py-3 text-base font-semibold text-white transition-transform duration-300 hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/40"
+            >
+              Study the system
+            </Link>
+            <Link
+              href="/preview"
+              className="inline-flex items-center justify-center rounded-full border border-white/10 px-8 py-3 text-base font-semibold text-white/80 transition-transform duration-300 hover:-translate-y-0.5 hover:border-white/40 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/30"
+            >
+              Share the preview
+            </Link>
+          </div>
         </div>
       </header>
 
-      <section className="space-y-12">
-        <SectionHeader
-          eyebrow="Core system"
-          title="Orchestrated agents keep writers in flow"
-          description="Every tool contributes to a shared ScriptDoc backbone. Voice directives, text edits, and reference assets stay synchronized from the first beat to the final export."
-        />
-        <div className="grid gap-6 md:grid-cols-2">
-          {coreFeatures.map((feature) => (
-            <GlassCard key={feature.title} title={`${feature.icon} ${feature.title}`}>
-              <p>{feature.description}</p>
-            </GlassCard>
-          ))}
-        </div>
-      </section>
-
-      <section className="space-y-12">
-        <SectionHeader
-          eyebrow="Workflow"
-          title="A guided path from interview to delivery"
-          description="Each stage adapts to the script type—commercial runtimes, episodic story arcs, or documentary narrative threads—all while preserving continuity and references."
-        />
-        <div className="grid gap-6 md:grid-cols-4">
-          {workflowStages.map((stage) => (
-            <GlassCard key={stage.label} title={stage.title} subtitle={stage.label} accent="indigo">
-              <p>{stage.description}</p>
-            </GlassCard>
-          ))}
-        </div>
-      </section>
-
-      <section className="space-y-12">
-        <SectionHeader
-          eyebrow="Platform pillars"
-          title="Designed for realtime collaboration between humans and AI"
-          description="Built on a Next.js front end, NestJS orchestration layer, and OpenAI realtime capabilities—backed by secure storage, accessibility features, and export automation."
-        />
-        <div className="grid gap-6 md:grid-cols-3">
-          {platformPillars.map((pillar) => (
-            <GlassCard key={pillar.title} title={pillar.title} accent="cyan">
-              <ul className="space-y-2 text-sm text-slate-200/90 md:text-base">
-                {pillar.points.map((point) => (
-                  <li key={point} className="flex items-start gap-2">
-                    <span className="mt-1 inline-block h-2.5 w-2.5 rounded-full bg-gradient-to-br from-cyan-400 to-indigo-400" />
-                    <span>{point}</span>
-                  </li>
-                ))}
-              </ul>
-            </GlassCard>
-          ))}
-        </div>
-      </section>
-
-      <footer className="relative overflow-hidden rounded-3xl border border-white/5 bg-white/5 p-10 text-center shadow-glow backdrop-blur-2xl md:p-16">
-        <div className="absolute inset-0 -z-10 bg-gradient-to-br from-indigo-500/20 via-cyan-500/10 to-transparent" />
-        <div className="mx-auto max-w-3xl space-y-6">
-          <h2 className="text-balance text-3xl font-semibold text-white md:text-5xl">
-            Join the founding storyteller program
+      <section className="grid gap-12 md:grid-cols-[1.1fr_0.9fr]">
+        <div className="space-y-8">
+          <h2 className="text-balance text-3xl font-semibold text-white md:text-4xl">
+            A stripped-back control room where every surface listens.
           </h2>
-          <p className="text-pretty text-base text-slate-300/80 md:text-lg">
-            Help shape Voice Script Studio’s realtime voice and multimodal workflows. Early access members receive concierge onboarding, direct feedback channels, and premium export credits.
+          <p className="text-pretty text-base text-zinc-300/90 md:text-lg">
+            Direct the session with voice and keep typing in reach for surgical edits. The interface is monochrome on purpose—your story, waveforms, and references are the only elements in motion. Scene boards and exports remain tucked away until you summon them
+            <sup className="ml-1 text-sm align-super text-zinc-400">
+              <Link href={footnotes[2].href}>{footnotes[2].number}</Link>
+            </sup>
+            .
           </p>
-          <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
-            <button className="inline-flex items-center justify-center rounded-full bg-white px-8 py-3 text-base font-semibold text-slate-950 shadow-lg transition-transform hover:scale-[1.02] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70">
-              Request early access
-            </button>
-            <button className="inline-flex items-center justify-center rounded-full border border-white/20 bg-white/10 px-8 py-3 text-base font-semibold text-white/90 backdrop-blur focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60">
-              View roadmap
-            </button>
-          </div>
+          <p className="text-pretty text-base text-zinc-400 md:text-lg">
+            The landing page is nothing but welcome and invitation. Production controls live beyond the fold so prospects catch the vibe first and dive into details later.
+          </p>
         </div>
+        <div className="grid gap-6">
+          {landing.vignettes.map((item) => (
+            <div
+              key={item.title}
+              className="group rounded-3xl border border-white/10 bg-white/5 p-6 transition-all duration-300 hover:border-white/30 hover:bg-white/10"
+            >
+              <div className="flex items-start justify-between">
+                <p className="text-lg font-semibold text-white">{item.title}</p>
+                <Link href={footnotes[item.footnote - 1].href} className="text-sm text-zinc-400 transition-colors group-hover:text-white">
+                  {item.footnote}
+                </Link>
+              </div>
+              <p className="mt-3 text-sm text-zinc-400 md:text-base">{item.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-10">
+        <h2 className="text-balance text-3xl font-semibold text-white md:text-4xl">How a session flows once you log in</h2>
+        <div className="grid gap-6 md:grid-cols-3">
+          {landing.cadence.map((step) => (
+            <div
+              key={step.heading}
+              className="rounded-3xl border border-white/10 bg-white/5 p-6 transition-transform duration-300 hover:-translate-y-1"
+            >
+              <p className="text-sm uppercase tracking-[0.3em] text-zinc-400">{step.heading}</p>
+              <p className="mt-4 text-pretty text-base text-zinc-300/90">{step.body}</p>
+              <Link href={footnotes[step.anchor - 1].href} className="mt-6 inline-flex text-sm text-zinc-400 hover:text-white">
+                Learn more ↗
+              </Link>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-[2.5rem] border border-white/10 bg-white/5 px-10 py-16 text-center shadow-glass backdrop-blur-xl md:px-16">
+        <div className="mx-auto max-w-3xl space-y-6">
+          <p className="text-xs uppercase tracking-[0.4em] text-zinc-500">{landing.callToAction.eyebrow}</p>
+          <h2 className="text-balance text-3xl font-semibold text-white md:text-5xl">{landing.callToAction.title}</h2>
+          <p className="text-pretty text-base text-zinc-300/85 md:text-lg">{landing.callToAction.description}</p>
+          <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
+            <Link
+              href={landing.callToAction.primaryCta.href}
+              className="inline-flex items-center justify-center rounded-full border border-white/20 bg-white px-8 py-3 text-base font-semibold text-zinc-950 transition-transform duration-300 hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60"
+            >
+              {landing.callToAction.primaryCta.label}
+            </Link>
+            <Link
+              href={landing.callToAction.secondaryCta.href}
+              className="inline-flex items-center justify-center rounded-full border border-white/20 bg-white/10 px-8 py-3 text-base font-semibold text-white transition-transform duration-300 hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/40"
+            >
+              {landing.callToAction.secondaryCta.label}
+            </Link>
+          </div>
+          <p className="text-sm text-zinc-500">{landing.callToAction.helper}</p>
+        </div>
+        <AccessRequestForm />
+      </section>
+
+      <footer className="space-y-6 border-t border-white/10 pt-10 text-sm text-zinc-500">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <p className="text-xs uppercase tracking-[0.35em] text-zinc-600">Feature footnotes</p>
+          <Link href="/faq" className="text-xs uppercase tracking-[0.35em] text-white hover:text-vs-accent-strong">
+            View the FAQ dossier
+          </Link>
+        </div>
+        <ol className="grid gap-3 md:grid-cols-2">
+          {footnotes.map((note) => (
+            <li key={note.number} className="flex items-baseline gap-3 rounded-2xl border border-white/5 bg-white/5 px-4 py-3">
+              <span className="text-xs font-semibold text-white/70">[{note.number}]</span>
+              <Link href={note.href} className="text-sm text-zinc-300 hover:text-white">
+                {note.title}
+              </Link>
+            </li>
+          ))}
+        </ol>
       </footer>
     </main>
   );

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -1,0 +1,76 @@
+import Link from "next/link";
+
+import { AnimatedHeadline } from "@/components/AnimatedHeadline";
+import { fetchFaqContent } from "@/lib/http";
+
+const previewPhrases = [
+  "Minimal monochrome hero",
+  "Voice-led studio canvas",
+  "Footnote-led feature dossier",
+];
+
+export const dynamic = "force-dynamic";
+
+export default async function PreviewPage() {
+  const faq = await fetchFaqContent();
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-16 px-6 py-16 md:px-10">
+      <header className="space-y-8">
+        <p className="text-xs uppercase tracking-[0.35em] text-zinc-500">Preview</p>
+        <div className="space-y-6">
+          <h1 className="text-balance text-4xl font-semibold text-white md:text-5xl">
+            Walk through the Script Speech experience in seconds.
+          </h1>
+          <AnimatedHeadline phrases={previewPhrases} />
+          <p className="max-w-3xl text-pretty text-base text-zinc-300/90 md:text-lg">
+            This condensed preview stitches together the highlights from the landing page, the studio canvas, and the FAQ dossier so stakeholders can scan the direction without logging in.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <Link href="/" className="rounded-full border border-white/10 bg-white/5 px-6 py-2 text-sm text-white hover:border-white/30 hover:bg-white/10">
+            Landing page
+          </Link>
+          <Link href="/studio" className="rounded-full border border-white/10 bg-white/5 px-6 py-2 text-sm text-white hover:border-white/30 hover:bg-white/10">
+            Studio canvas
+          </Link>
+          <Link href="/faq" className="rounded-full border border-white/10 bg-white/5 px-6 py-2 text-sm text-white hover:border-white/30 hover:bg-white/10">
+            FAQ dossier
+          </Link>
+        </div>
+      </header>
+
+      <section className="grid gap-6 md:grid-cols-2">
+        {faq.coreFeatures.slice(0, 4).map((feature, index) => (
+          <div key={feature.slug} className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-glass backdrop-blur transition hover:border-white/25 hover:bg-white/10">
+            <p className="text-xs uppercase tracking-[0.35em] text-zinc-500">Feature {index + 1}</p>
+            <h2 className="mt-3 text-lg font-semibold text-white">{feature.title}</h2>
+            <p className="mt-3 text-sm text-zinc-300">{feature.description}</p>
+          </div>
+        ))}
+      </section>
+
+      <section className="grid gap-6 md:grid-cols-2">
+        <div className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+          <p className="text-xs uppercase tracking-[0.35em] text-zinc-500">Studio canvas vignette</p>
+          <p className="mt-4 text-sm text-zinc-300">
+            Voice chat, quick prompts, and the living ScriptDoc sit inside a restrained control room. Micro animations keep focus on the session instead of UI chrome.
+          </p>
+        </div>
+        <div className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+          <p className="text-xs uppercase tracking-[0.35em] text-zinc-500">FAQ dossier</p>
+          <p className="mt-4 text-sm text-zinc-300">
+            Footnotes on the landing page route here so prospects can deep dive without cluttering the hero moment.
+          </p>
+        </div>
+      </section>
+
+      <footer className="space-y-4 border-t border-white/10 pt-8 text-sm text-zinc-500">
+        <p className="text-xs uppercase tracking-[0.35em] text-zinc-600">Share</p>
+        <p className="text-sm text-zinc-400">
+          Drop this preview link in investor updates or team chats when you need a fast walkthrough of Script Speech.
+        </p>
+      </footer>
+    </main>
+  );
+}

--- a/src/app/studio/page.tsx
+++ b/src/app/studio/page.tsx
@@ -1,0 +1,102 @@
+import Link from "next/link";
+
+const prompts = [
+  "Outline the cold open with a single location",
+  "Drop in references for lighting and costume",
+  "Preview export package"
+];
+
+const transcript = [
+  {
+    role: "Director",
+    content: "Let's reframe the second beat so the reveal happens off screen.",
+  },
+  {
+    role: "Script Speech",
+    content: "Copy. Updating beat two with off-screen reveal and adjusting dialogue pacing to create anticipation.",
+  },
+  {
+    role: "Director",
+    content: "Tag the location with the exterior reference board and prep export for review.",
+  },
+];
+
+export default function StudioPage() {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-6xl flex-col gap-16 px-6 py-16 md:px-10">
+      <header className="flex flex-col gap-4">
+        <p className="text-xs uppercase tracking-[0.35em] text-zinc-500">Workspace</p>
+        <h1 className="text-4xl font-semibold text-white md:text-5xl">Script Speech studio canvas</h1>
+        <p className="max-w-3xl text-base text-zinc-400 md:text-lg">
+          A monochrome control room centered around a living ScriptDoc. Speak or type to guide the agents, drag reference panes to the timeline, and keep the view focused on what matters.
+        </p>
+        <Link href="/" className="text-sm text-zinc-300 hover:text-white">
+          Return to the landing page ↗
+        </Link>
+      </header>
+
+      <section className="grid gap-10 md:grid-cols-[1.4fr_1fr]">
+        <div className="space-y-6">
+          <div className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+            <div className="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-zinc-500">
+              <span>Scene canvas</span>
+              <span>Live sync</span>
+            </div>
+            <div className="mt-6 grid gap-4 md:grid-cols-2">
+              <div className="space-y-3 rounded-2xl border border-white/10 bg-vs-panel p-4">
+                <p className="text-sm font-semibold text-white">Outline</p>
+                <p className="text-sm text-zinc-400">
+                  Beat markers snap to your spoken timing. Drag to reorder or dictate adjustments for instant updates.
+                </p>
+              </div>
+              <div className="space-y-3 rounded-2xl border border-white/10 bg-vs-panel p-4">
+                <p className="text-sm font-semibold text-white">Script view</p>
+                <p className="text-sm text-zinc-400">
+                  Scene text updates line-by-line with each directive. Hand off or continue typing without switching modes.
+                </p>
+              </div>
+              <div className="space-y-3 rounded-2xl border border-white/10 bg-vs-panel p-4">
+                <p className="text-sm font-semibold text-white">Reference rail</p>
+                <p className="text-sm text-zinc-400">
+                  Slide boards and clips in from the edge, attach them to beats, and keep exports aligned.
+                </p>
+              </div>
+              <div className="space-y-3 rounded-2xl border border-white/10 bg-vs-panel p-4">
+                <p className="text-sm font-semibold text-white">Export queue</p>
+                <p className="text-sm text-zinc-400">
+                  Queue Fountain, FDX, and PDF without leaving the canvas. Status pulses softly when jobs finish.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <aside className="space-y-6">
+          <div className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+            <div className="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-zinc-500">
+              <span>Voice chat</span>
+              <span>Live</span>
+            </div>
+            <ul className="mt-6 space-y-5">
+              {transcript.map((message) => (
+                <li key={message.content} className="space-y-2 rounded-2xl border border-white/10 bg-vs-panel p-4 transition-transform duration-300 hover:-translate-y-0.5">
+                  <p className="text-xs uppercase tracking-[0.25em] text-zinc-500">{message.role}</p>
+                  <p className="text-sm text-zinc-300">{message.content}</p>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+            <p className="text-xs uppercase tracking-[0.35em] text-zinc-500">Quick prompts</p>
+            <ul className="mt-4 space-y-3">
+              {prompts.map((prompt) => (
+                <li key={prompt} className="rounded-2xl border border-white/10 bg-vs-panel p-3 text-sm text-zinc-300 transition-colors duration-300 hover:border-white/25 hover:text-white">
+                  {prompt}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </aside>
+      </section>
+    </main>
+  );
+}

--- a/src/components/AccessRequestForm.tsx
+++ b/src/components/AccessRequestForm.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState, useTransition, type FormEvent } from "react";
+
+const initialState = {
+  email: "",
+  message: "",
+};
+
+export function AccessRequestForm() {
+  const [formState, setFormState] = useState(initialState);
+  const [status, setStatus] = useState<"idle" | "success" | "error">("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setStatus("idle");
+    setErrorMessage(null);
+
+    startTransition(async () => {
+      try {
+        const response = await fetch("/api/request-access", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            email: formState.email,
+            message: formState.message,
+          }),
+        });
+
+        const payload = await response.json();
+
+        if (!response.ok || !payload?.success) {
+          const message = payload?.message ?? "Unable to submit your request right now.";
+          throw new Error(message);
+        }
+
+        setFormState(initialState);
+        setStatus("success");
+      } catch (error) {
+        setStatus("error");
+        setErrorMessage(
+          error instanceof Error ? error.message : "Something went wrong. Please try again.",
+        );
+      }
+    });
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="mt-8 space-y-4 rounded-3xl border border-white/10 bg-black/20 p-6 text-left shadow-glass"
+    >
+      <div className="grid gap-4 md:grid-cols-[1.2fr_0.8fr]">
+        <label className="flex flex-col gap-2">
+          <span className="text-xs uppercase tracking-[0.35em] text-zinc-500">Email</span>
+          <input
+            type="email"
+            required
+            value={formState.email}
+            onChange={(event) =>
+              setFormState((state) => ({ ...state, email: event.target.value }))
+            }
+            className="w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white placeholder:text-zinc-500 focus:border-white/40 focus:outline-none focus:ring-0"
+            placeholder="you@studio.com"
+          />
+        </label>
+        <label className="flex flex-col gap-2">
+          <span className="text-xs uppercase tracking-[0.35em] text-zinc-500">Project focus</span>
+          <input
+            type="text"
+            value={formState.message}
+            onChange={(event) =>
+              setFormState((state) => ({ ...state, message: event.target.value }))
+            }
+            className="w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white placeholder:text-zinc-500 focus:border-white/40 focus:outline-none focus:ring-0"
+            placeholder="Commercial short, feature, episodic"
+          />
+        </label>
+      </div>
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <p className="text-xs text-zinc-500 md:max-w-sm">
+          Share your best contact email and what you are producing next. We will schedule a 15-minute run-through of Script Speech.
+        </p>
+        <button
+          type="submit"
+          disabled={isPending}
+          className="inline-flex items-center justify-center rounded-full border border-white/20 bg-white px-6 py-2 text-sm font-semibold text-zinc-950 transition-transform duration-300 hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white disabled:cursor-not-allowed disabled:opacity-80"
+        >
+          {isPending ? "Sending…" : "Request access"}
+        </button>
+      </div>
+      {status === "success" && (
+        <p className="text-sm text-emerald-400">
+          Request received. We will reach out shortly with onboarding details.
+        </p>
+      )}
+      {status === "error" && errorMessage && (
+        <p className="text-sm text-rose-400">{errorMessage}</p>
+      )}
+    </form>
+  );
+}

--- a/src/components/AnimatedHeadline.tsx
+++ b/src/components/AnimatedHeadline.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+const ROTATION_INTERVAL = 3600;
+
+interface AnimatedHeadlineProps {
+  phrases: string[];
+}
+
+export function AnimatedHeadline({ phrases }: AnimatedHeadlineProps) {
+  const safePhrases = useMemo(() => (phrases.length ? phrases : [""]), [phrases]);
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    if (safePhrases.length <= 1) {
+      return;
+    }
+
+    const timer = window.setInterval(() => {
+      setIndex((current) => (current + 1) % safePhrases.length);
+    }, ROTATION_INTERVAL);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [safePhrases.length]);
+
+  return (
+    <span className="relative inline-flex h-[1.4em] overflow-hidden align-middle text-gradient-sheen">
+      {safePhrases.map((phrase, phraseIndex) => (
+        <span
+          key={phrase}
+          className={`absolute inset-x-0 text-balance text-left text-3xl font-medium tracking-tight transition-all duration-700 ease-out md:text-5xl ${
+            phraseIndex === index ? "translate-y-0 opacity-100" : "translate-y-full opacity-0"
+          }`}
+        >
+          {phrase}
+        </span>
+      ))}
+      <span className="invisible text-3xl md:text-5xl">{safePhrases[index]}</span>
+    </span>
+  );
+}

--- a/src/components/GlassCard.tsx
+++ b/src/components/GlassCard.tsx
@@ -4,24 +4,31 @@ interface GlassCardProps {
   title: string;
   subtitle?: string;
   children: ReactNode;
-  accent?: "cyan" | "indigo";
+  accent?: "light" | "dim";
+  id?: string;
+  className?: string;
 }
 
 const accentClassnames: Record<NonNullable<GlassCardProps["accent"]>, string> = {
-  cyan: "from-cyan-500/40 to-cyan-400/10",
-  indigo: "from-indigo-500/40 to-indigo-400/10",
+  light: "from-white/60 to-white/0",
+  dim: "from-zinc-500/40 to-zinc-800/10",
 };
 
-export function GlassCard({ title, subtitle, children, accent = "cyan" }: GlassCardProps) {
+export function GlassCard({ title, subtitle, children, accent = "light", id, className }: GlassCardProps) {
   return (
-    <section className="rounded-3xl border border-white/10 bg-vs-panel p-8 shadow-glass backdrop-blur-xl">
+    <section
+      id={id}
+      className={`rounded-3xl border border-white/10 bg-vs-panel p-8 shadow-glass backdrop-blur-xl transition-transform duration-300 hover:-translate-y-1 ${
+        className ?? ""
+      }`}
+    >
       <div
         className={`mb-6 inline-flex flex-col gap-1 bg-gradient-to-br ${accentClassnames[accent]} bg-clip-text text-left`}
       >
         <h2 className="text-2xl font-semibold text-transparent md:text-3xl">{title}</h2>
-        {subtitle ? <p className="text-sm text-slate-300/90 md:text-base">{subtitle}</p> : null}
+        {subtitle ? <p className="text-sm text-zinc-300/90 md:text-base">{subtitle}</p> : null}
       </div>
-      <div className="space-y-4 text-slate-200/90">{children}</div>
+      <div className="space-y-4 text-zinc-200/90">{children}</div>
     </section>
   );
 }

--- a/src/components/SectionHeader.tsx
+++ b/src/components/SectionHeader.tsx
@@ -14,11 +14,11 @@ export function SectionHeader({ eyebrow, title, description, alignment = "center
   return (
     <div className={`mx-auto flex max-w-4xl flex-col gap-4 ${alignmentClassnames[alignment]}`}>
       {eyebrow ? (
-        <span className="text-xs font-semibold uppercase tracking-[0.3em] text-vs-accent">{eyebrow}</span>
+        <span className="text-xs font-semibold uppercase tracking-[0.3em] text-vs-accent-strong">{eyebrow}</span>
       ) : null}
       <h2 className="text-balance text-3xl font-semibold text-white md:text-5xl">{title}</h2>
       {description ? (
-        <p className="text-pretty text-base text-slate-300/85 md:text-lg">{description}</p>
+        <p className="text-pretty text-base text-zinc-300/85 md:text-lg">{description}</p>
       ) : null}
     </div>
   );

--- a/src/data/coreFeatures.ts
+++ b/src/data/coreFeatures.ts
@@ -1,26 +1,26 @@
 export const coreFeatures = [
   {
+    slug: "conversational-onboarding",
     title: "Conversational Onboarding",
     description:
       "Slot-filling voice interview captures script format, tone, characters, and references. Users can pause, revise, or drop supporting assets mid-flow.",
-    icon: "🎙️",
   },
   {
+    slug: "adaptive-drafting",
     title: "Adaptive Drafting Pipeline",
     description:
       "Outline, beats, and scene drafts stay in sync with inline text edits and voice corrections. Intelligent retries keep the conversation on track.",
-    icon: "🧠",
   },
   {
+    slug: "reference-library",
     title: "Multimodal Reference Library",
     description:
       "Attach stills, motion clips, or links to characters, locations, props, and tone boards. Drag references into scene notes and export them alongside drafts.",
-    icon: "🖼️",
   },
   {
+    slug: "production-ready-outputs",
     title: "Production-Ready Outputs",
     description:
       "Generate Fountain, FDX, DOCX/RTF, PDF, and TXT from a canonical ScriptDoc model. Email exports with presigned links instantly.",
-    icon: "📤",
   },
 ];

--- a/src/data/landing.ts
+++ b/src/data/landing.ts
@@ -1,0 +1,104 @@
+export type LandingHero = {
+  title: string;
+  phrases: string[];
+  description: string;
+};
+
+export type LandingVignette = {
+  title: string;
+  description: string;
+  footnote: number;
+};
+
+export type LandingCadenceStep = {
+  heading: string;
+  body: string;
+  anchor: number;
+};
+
+export type LandingCallToAction = {
+  eyebrow: string;
+  title: string;
+  description: string;
+  primaryCta: {
+    label: string;
+    href: string;
+  };
+  secondaryCta: {
+    label: string;
+    href: string;
+  };
+  helper: string;
+};
+
+export type LandingContent = {
+  hero: LandingHero;
+  vignettes: LandingVignette[];
+  cadence: LandingCadenceStep[];
+  callToAction: LandingCallToAction;
+};
+
+export const landingContent: LandingContent = {
+  hero: {
+    title: "The voice-led story studio for directors who think out loud.",
+    phrases: [
+      "Draft cinema-ready stories by speaking",
+      "Sketch acts, beats, and shots without friction",
+      "Deliver production files the same day",
+    ],
+    description:
+      "Script Speech keeps the landing page focused on the mood: low light, confident lines, and zero clutter. Speak your vision and the canvas adapts without compromising precision.",
+  },
+  vignettes: [
+    {
+      title: "Voice directs the room",
+      description:
+        "Speak the brief, calibrate tone, and watch the story spine assemble itself. Text is always there when you need to fine tune.",
+      footnote: 1,
+    },
+    {
+      title: "Canvas stays in sync",
+      description:
+        "Outline, beat grid, and script view are rendered from one ScriptDoc core so every revision lands everywhere at once.",
+      footnote: 2,
+    },
+    {
+      title: "References travel with you",
+      description:
+        "Boards, clips, and research snippets follow each scene and export with your package. Nothing gets stranded in a drive.",
+      footnote: 3,
+    },
+  ],
+  cadence: [
+    {
+      heading: "1. Tune the signal",
+      body: "A minimalist intake checks format, pacing, and references while your waveform shows the room is listening.",
+      anchor: 1,
+    },
+    {
+      heading: "2. Move the pieces",
+      body: "Outline and beat editors adapt instantly to voice or keyboard adjustments so structure never lags behind.",
+      anchor: 2,
+    },
+    {
+      heading: "3. Deliver with certainty",
+      body: "Queue exports, share secure links, and walk into your next session with production-ready files in hand.",
+      anchor: 4,
+    },
+  ],
+  callToAction: {
+    eyebrow: "Early collaborator program",
+    title: "Help us tune Script Speech for productions that move fast.",
+    description:
+      "Founding teams receive guided onboarding, access to the redesigned studio canvas, and direct lines to the crew building the experience.",
+    primaryCta: {
+      label: "Preview the canvas",
+      href: "/studio",
+    },
+    secondaryCta: {
+      label: "Study the system",
+      href: "/faq",
+    },
+    helper: "Prefer a personal intro? Request access and we will respond within one business day.",
+  },
+};

--- a/src/data/platformPillars.ts
+++ b/src/data/platformPillars.ts
@@ -1,5 +1,6 @@
 export const platformPillars = [
   {
+    slug: "realtime-voice",
     title: "Realtime Voice",
     points: [
       "WebRTC-powered capture with waveform feedback",
@@ -8,6 +9,7 @@ export const platformPillars = [
     ],
   },
   {
+    slug: "script-intelligence",
     title: "Script Intelligence",
     points: [
       "Canonical ScriptDoc JSON keeps every tool aligned",
@@ -16,6 +18,7 @@ export const platformPillars = [
     ],
   },
   {
+    slug: "reference-driven",
     title: "Reference-Driven",
     points: [
       "Upload large media with background processing",

--- a/src/data/workflowStages.ts
+++ b/src/data/workflowStages.ts
@@ -1,23 +1,27 @@
 export const workflowStages = [
   {
+    slug: "interview-and-calibrate",
     label: "Onboard",
     title: "Interview & Calibrate",
     description:
       "Voice calibration, intake questions, and reference asset capture flow into a shared project brief with autosave.",
   },
   {
+    slug: "outline-to-beats",
     label: "Plan",
     title: "Outline to Beats",
     description:
       "Planner agent turns the confirmed brief into outlines and beat sheets that respond to voice or text revisions instantly.",
   },
   {
+    slug: "scenes-and-dialogue",
     label: "Draft",
     title: "Scenes & Dialogue",
     description:
       "Scene writer collaborates with dialogue polisher and continuity checker to maintain tone, pacing, and character arcs.",
   },
   {
+    slug: "export-and-share",
     label: "Deliver",
     title: "Export & Share",
     description:

--- a/src/lib/accessRequests.ts
+++ b/src/lib/accessRequests.ts
@@ -1,0 +1,40 @@
+export type AccessRequestInput = {
+  email: string;
+  message?: string;
+};
+
+export type AccessRequestRecord = {
+  id: string;
+  email: string;
+  message?: string;
+  submittedAt: string;
+};
+
+const requests: AccessRequestRecord[] = [];
+
+export async function createAccessRequest({
+  email,
+  message,
+}: AccessRequestInput): Promise<AccessRequestRecord> {
+  const trimmedEmail = email.trim();
+  const trimmedMessage = message?.trim();
+
+  if (!trimmedEmail) {
+    throw new Error("Email is required");
+  }
+
+  const entry: AccessRequestRecord = {
+    id: crypto.randomUUID(),
+    email: trimmedEmail.toLowerCase(),
+    message: trimmedMessage,
+    submittedAt: new Date().toISOString(),
+  };
+
+  requests.push(entry);
+
+  return entry;
+}
+
+export async function listAccessRequests(): Promise<AccessRequestRecord[]> {
+  return [...requests].reverse();
+}

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,0 +1,50 @@
+import type { FAQContent } from "@/lib/siteData";
+import type { LandingContent } from "@/data/landing";
+import { headers } from "next/headers";
+
+function resolveBaseUrl() {
+  const headerList = headers();
+  const forwardedProto = headerList.get("x-forwarded-proto");
+  const inferredProto = forwardedProto ?? (process.env.VERCEL_URL ? "https" : "http");
+  const host =
+    headerList.get("x-forwarded-host") ?? headerList.get("host") ?? process.env.VERCEL_URL;
+
+  if (host) {
+    const normalizedHost = host.startsWith("http") ? host : `${inferredProto}://${host}`;
+    return normalizedHost;
+  }
+
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
+  if (siteUrl) {
+    return siteUrl;
+  }
+
+  const port = process.env.PORT ?? "3000";
+  return `http://localhost:${port}`;
+}
+
+async function fetchFromApi<T>(path: string, init?: RequestInit) {
+  const baseUrl = resolveBaseUrl();
+  const response = await fetch(`${baseUrl}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...init?.headers,
+    },
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${path}: ${response.statusText}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+export async function fetchLandingContent() {
+  return fetchFromApi<LandingContent>("/api/landing");
+}
+
+export async function fetchFaqContent() {
+  return fetchFromApi<FAQContent>("/api/faq");
+}

--- a/src/lib/siteData.ts
+++ b/src/lib/siteData.ts
@@ -1,0 +1,22 @@
+import { landingContent, type LandingContent } from "@/data/landing";
+import { coreFeatures } from "@/data/coreFeatures";
+import { platformPillars } from "@/data/platformPillars";
+import { workflowStages } from "@/data/workflowStages";
+
+export type FAQContent = {
+  coreFeatures: typeof coreFeatures;
+  workflowStages: typeof workflowStages;
+  platformPillars: typeof platformPillars;
+};
+
+export async function getLandingContent(): Promise<LandingContent> {
+  return structuredClone(landingContent);
+}
+
+export async function getFaqContent(): Promise<FAQContent> {
+  return {
+    coreFeatures: structuredClone(coreFeatures),
+    workflowStages: structuredClone(workflowStages),
+    platformPillars: structuredClone(platformPillars),
+  };
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,17 +9,17 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        "vs-background": "#020617",
-        "vs-panel": "rgba(15, 23, 42, 0.6)",
-        "vs-accent": "#38bdf8",
-        "vs-accent-strong": "#818cf8"
+        "vs-background": "#050505",
+        "vs-panel": "rgba(24, 24, 27, 0.85)",
+        "vs-accent": "#f5f5f5",
+        "vs-accent-strong": "#d4d4d8"
       },
       backdropBlur: {
         xs: "2px"
       },
       boxShadow: {
-        glass: "0 20px 45px -25px rgba(56, 189, 248, 0.45)",
-        glow: "0 0 50px rgba(129, 140, 248, 0.35)"
+        glass: "0 24px 60px -30px rgba(250, 250, 250, 0.12)",
+        glow: "0 0 60px rgba(212, 212, 216, 0.2)"
       }
     }
   },


### PR DESCRIPTION
## Summary
- expose landing and FAQ datasets through shared content modules and API routes
- update landing, preview, and FAQ pages to fetch dynamic content while keeping the grayscale presentation intact
- add an access request endpoint with a client-side form to collect collaborator interest from the call-to-action panel

## Testing
- npm run lint *(fails: `next` command not found because dependencies cannot be installed in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e9a7a1384832297e1f58142a145a7)