### PR TITLE
Add realtime voice chat integration

### DIFF
--- a/src/app/api/realtime/session/route.ts
+++ b/src/app/api/realtime/session/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from "next/server";
+
+const DEFAULT_REALTIME_MODEL = process.env.OPENAI_REALTIME_MODEL ?? "gpt-4o-realtime-preview-2024-12-10";
+const DEFAULT_REALTIME_VOICE = process.env.OPENAI_REALTIME_VOICE ?? "verse";
+
+async function requestOrchestrationSession() {
+  const orchestrationBase = process.env.ORCHESTRATION_BASE_URL ?? process.env.ORCHESTRATION_URL;
+  if (!orchestrationBase) {
+    return null;
+  }
+
+  try {
+    const url = new URL("/api/realtime/session", orchestrationBase);
+    const headers: HeadersInit = {
+      "Content-Type": "application/json",
+    };
+
+    if (process.env.ORCHESTRATION_API_KEY) {
+      headers.Authorization = `Bearer ${process.env.ORCHESTRATION_API_KEY}`;
+    }
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({}),
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      console.warn("Realtime orchestration session request failed", response.status, await response.text());
+      return null;
+    }
+
+    return (await response.json()) as unknown;
+  } catch (error) {
+    console.error("Realtime orchestration session request error", error);
+    return null;
+  }
+}
+
+async function createOpenAISession() {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error("OPENAI_API_KEY is not configured");
+  }
+
+  const response = await fetch("https://api.openai.com/v1/realtime/sessions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: DEFAULT_REALTIME_MODEL,
+      voice: DEFAULT_REALTIME_VOICE,
+    }),
+    cache: "no-store",
+  });
+
+  const payload = await response.json();
+
+  if (!response.ok) {
+    const errorMessage =
+      typeof payload === "object" && payload !== null && "error" in payload
+        ? (payload.error as { message?: string }).message ?? "Unknown OpenAI response error"
+        : "Failed to create OpenAI realtime session";
+    throw new Error(errorMessage);
+  }
+
+  return payload as unknown;
+}
+
+async function createSession() {
+  const orchestrationSession = await requestOrchestrationSession();
+  if (orchestrationSession) {
+    return orchestrationSession;
+  }
+
+  return createOpenAISession();
+}
+
+export async function POST() {
+  try {
+    const session = await createSession();
+    return NextResponse.json(session, {
+      status: 200,
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to create realtime session";
+    return NextResponse.json(
+      { error: message },
+      {
+        status: 500,
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      },
+    );
+  }
+}
+
+export async function GET() {
+  return POST();
+}

--- a/src/app/studio/page.tsx
+++ b/src/app/studio/page.tsx
@@ -1,24 +1,11 @@
 import Link from "next/link";
 
+import { VoiceChatPanel } from "./voice-chat-panel";
+
 const prompts = [
   "Outline the cold open with a single location",
   "Drop in references for lighting and costume",
   "Preview export package"
-];
-
-const transcript = [
-  {
-    role: "Director",
-    content: "Let's reframe the second beat so the reveal happens off screen.",
-  },
-  {
-    role: "Script Speech",
-    content: "Copy. Updating beat two with off-screen reveal and adjusting dialogue pacing to create anticipation.",
-  },
-  {
-    role: "Director",
-    content: "Tag the location with the exterior reference board and prep export for review.",
-  },
 ];
 
 export default function StudioPage() {
@@ -71,20 +58,7 @@ export default function StudioPage() {
           </div>
         </div>
         <aside className="space-y-6">
-          <div className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
-            <div className="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-zinc-500">
-              <span>Voice chat</span>
-              <span>Live</span>
-            </div>
-            <ul className="mt-6 space-y-5">
-              {transcript.map((message) => (
-                <li key={message.content} className="space-y-2 rounded-2xl border border-white/10 bg-vs-panel p-4 transition-transform duration-300 hover:-translate-y-0.5">
-                  <p className="text-xs uppercase tracking-[0.25em] text-zinc-500">{message.role}</p>
-                  <p className="text-sm text-zinc-300">{message.content}</p>
-                </li>
-              ))}
-            </ul>
-          </div>
+          <VoiceChatPanel />
           <div className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
             <p className="text-xs uppercase tracking-[0.35em] text-zinc-500">Quick prompts</p>
             <ul className="mt-4 space-y-3">

--- a/src/app/studio/voice-chat-panel.tsx
+++ b/src/app/studio/voice-chat-panel.tsx
@@ -1,0 +1,338 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createRealtimeClient, type RealtimeClientEvent } from "@/lib/realtime";
+
+type TranscriptMessage = {
+  id: string;
+  role: string;
+  text: string;
+  final: boolean;
+  updatedAt: number;
+};
+
+const MAX_MESSAGES = 20;
+
+function formatRole(role?: string) {
+  if (!role) {
+    return "Script Speech";
+  }
+
+  const normalized = role.toLowerCase();
+  if (normalized === "user") {
+    return "Director";
+  }
+
+  if (normalized === "assistant") {
+    return "Script Speech";
+  }
+
+  return role.charAt(0).toUpperCase() + role.slice(1);
+}
+
+function extractTextFromContent(content: unknown): string {
+  if (!content) {
+    return "";
+  }
+
+  const fragments: string[] = [];
+
+  const visit = (value: unknown) => {
+    if (!value) {
+      return;
+    }
+
+    if (typeof value === "string") {
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        visit(entry);
+      }
+      return;
+    }
+
+    if (typeof value === "object") {
+      for (const [key, entry] of Object.entries(value)) {
+        if (key === "text" || key === "transcript" || key === "value") {
+          if (typeof entry === "string") {
+            fragments.push(entry);
+          } else if (Array.isArray(entry)) {
+            for (const nested of entry) {
+              if (typeof nested === "string") {
+                fragments.push(nested);
+              }
+            }
+          }
+        } else if (key === "content" || key === "delta" || key === "output" || key === "outputs") {
+          visit(entry);
+        }
+      }
+    }
+  };
+
+  visit(content);
+  return fragments.join("").trim();
+}
+
+export function VoiceChatPanel() {
+  const [messages, setMessages] = useState<TranscriptMessage[]>([]);
+  const [connectionState, setConnectionState] = useState<RTCPeerConnectionState>("new");
+  const [isMicActive, setIsMicActive] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  const clientRef = useRef(createRealtimeClient());
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setPrefersReducedMotion(mediaQuery.matches);
+
+    update();
+    mediaQuery.addEventListener("change", update);
+
+    return () => {
+      mediaQuery.removeEventListener("change", update);
+    };
+  }, []);
+
+  const processPayload = useCallback(
+    (payload: unknown) => {
+      if (!payload || typeof payload !== "object") {
+        return;
+      }
+
+      const data = payload as Record<string, unknown>;
+      const type = typeof data.type === "string" ? data.type : undefined;
+      if (!type) {
+        return;
+      }
+
+      const updateMessage = (
+        id: string | undefined,
+        role: string | undefined,
+        text: string | undefined,
+        final: boolean | undefined,
+        append: boolean,
+      ) => {
+        if (!id) {
+          return;
+        }
+
+        setMessages((previous) => {
+          const next = [...previous];
+          const index = next.findIndex((message) => message.id === id);
+          const resolvedRole = role ? formatRole(role) : undefined;
+          const trimmedText = text?.trim();
+
+          if (index >= 0) {
+            const existing = next[index];
+            const newText = trimmedText ? (append ? `${existing.text}${trimmedText}` : trimmedText) : existing.text;
+
+            next[index] = {
+              ...existing,
+              role: resolvedRole ?? existing.role,
+              text: newText,
+              final: final ?? existing.final,
+              updatedAt: Date.now(),
+            };
+          } else if (trimmedText) {
+            next.push({
+              id,
+              role: resolvedRole ?? formatRole(role),
+              text: trimmedText,
+              final: Boolean(final),
+              updatedAt: Date.now(),
+            });
+          }
+
+          if (next.length > MAX_MESSAGES) {
+            return next.slice(-MAX_MESSAGES);
+          }
+
+          return next;
+        });
+      };
+
+      if (type === "conversation.item.created") {
+        const item = data.item as Record<string, unknown> | undefined;
+        const text = extractTextFromContent(item?.content);
+        if (text) {
+          updateMessage(item?.id as string | undefined, item?.role as string | undefined, text, item?.status === "completed", false);
+        }
+        return;
+      }
+
+      if (type === "conversation.item.delta") {
+        const delta = data.delta as Record<string, unknown> | undefined;
+        const text = extractTextFromContent(delta?.content ?? delta);
+        if (text) {
+          updateMessage(data.item_id as string | undefined, (delta?.role ?? data.role) as string | undefined, text, delta?.status === "completed", true);
+        }
+        return;
+      }
+
+      if (type === "conversation.item.completed") {
+        updateMessage(data.item_id as string | undefined, undefined, undefined, true, false);
+        return;
+      }
+
+      if (type === "response.delta") {
+        const response = data.response as Record<string, unknown> | undefined;
+        const delta = data.delta as Record<string, unknown> | undefined;
+        const text = extractTextFromContent(delta?.content ?? delta?.output ?? delta);
+        if (text) {
+          updateMessage(
+            (response?.id ?? data.id) as string | undefined,
+            (delta?.role ?? response?.role ?? data.role) as string | undefined,
+            text,
+            false,
+            true,
+          );
+        }
+        return;
+      }
+
+      if (type === "response.completed") {
+        const response = data.response as Record<string, unknown> | undefined;
+        const text = extractTextFromContent(response?.output ?? response?.outputs ?? response);
+        if (text) {
+          updateMessage(response?.id as string | undefined, response?.role as string | undefined, text, true, false);
+        }
+      }
+    },
+    [setMessages],
+  );
+
+  useEffect(() => {
+    const client = clientRef.current;
+
+    if (audioRef.current) {
+      client.attachRemoteAudioElement(audioRef.current);
+    }
+
+    const unsubscribe = client.events.subscribe((event: RealtimeClientEvent) => {
+      if (event.type === "connection-state") {
+        setConnectionState(event.state);
+        if (event.state === "failed" || event.state === "disconnected" || event.state === "closed") {
+          setIsMicActive(false);
+        }
+        return;
+      }
+
+      if (event.type === "error") {
+        setError(event.error.message);
+        return;
+      }
+
+      if (event.type === "realtime-event") {
+        setError(null);
+        processPayload(event.payload);
+      }
+    });
+
+    setConnectionState("connecting");
+    client
+      .connect()
+      .then(() => {
+        if (audioRef.current) {
+          client.attachRemoteAudioElement(audioRef.current);
+        }
+      })
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : "Failed to connect to realtime session");
+        setConnectionState("failed");
+      });
+
+    return () => {
+      unsubscribe();
+      client.stopMicrophone();
+      client.disconnect();
+      setIsMicActive(false);
+    };
+  }, [processPayload]);
+
+  const sortedMessages = useMemo(() => {
+    return [...messages].sort((a, b) => a.updatedAt - b.updatedAt);
+  }, [messages]);
+
+  const statusLabel = useMemo(() => {
+    switch (connectionState) {
+      case "connected":
+        return "Live";
+      case "connecting":
+      case "new":
+        return "Connecting";
+      case "failed":
+      case "disconnected":
+      case "closed":
+        return "Offline";
+      default:
+        return "Offline";
+    }
+  }, [connectionState]);
+
+  const handleMicToggle = useCallback(async () => {
+    const client = clientRef.current;
+
+    if (isMicActive) {
+      client.stopMicrophone();
+      setIsMicActive(false);
+      return;
+    }
+
+    try {
+      await client.startMicrophone();
+      setIsMicActive(true);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Microphone access was denied");
+      setIsMicActive(false);
+    }
+  }, [isMicActive]);
+
+  const micDisabled = !isMicActive && connectionState !== "connected";
+  const listItemMotion = prefersReducedMotion ? "" : " transition-transform duration-300 hover:-translate-y-0.5";
+  const hoverMotion = prefersReducedMotion ? "" : " transition-colors duration-300";
+
+  return (
+    <div className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+      <div className="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-zinc-500">
+        <span>Voice chat</span>
+        <span className={statusLabel === "Live" ? "text-emerald-400" : "text-zinc-500"}>{statusLabel}</span>
+      </div>
+      <ul className="mt-6 space-y-5">
+        {sortedMessages.length === 0 ? (
+          <li className={`rounded-2xl border border-dashed border-white/10 bg-vs-panel/40 p-4 text-sm text-zinc-400${hoverMotion}`}>
+            <p>Connect your microphone to start capturing directives for the Script Speech agents.</p>
+          </li>
+        ) : (
+          sortedMessages.map((message) => (
+            <li
+              key={message.id}
+              className={`space-y-2 rounded-2xl border border-white/10 bg-vs-panel p-4${listItemMotion}`}
+            >
+              <p className="text-xs uppercase tracking-[0.25em] text-zinc-500">{message.role}</p>
+              <p className="text-sm text-zinc-300">{message.text}</p>
+            </li>
+          ))
+        )}
+      </ul>
+      <button
+        type="button"
+        onClick={handleMicToggle}
+        disabled={micDisabled}
+        className={`mt-6 flex w-full items-center justify-between rounded-2xl border border-white/10 bg-vs-panel px-4 py-3 text-sm text-zinc-300 disabled:cursor-not-allowed disabled:opacity-60${hoverMotion} ${
+          isMicActive ? "border-emerald-400/40 text-white" : ""
+        }`}
+      >
+        <span>{isMicActive ? "Stop microphone" : "Start microphone"}</span>
+        <span className={`h-2 w-2 rounded-full ${isMicActive ? "bg-emerald-400" : "bg-zinc-500"}`} aria-hidden="true" />
+      </button>
+      {error ? <p className="mt-4 text-xs text-rose-300">{error}</p> : null}
+      <audio ref={audioRef} className="hidden" />
+    </div>
+  );
+}

--- a/src/lib/realtime/index.ts
+++ b/src/lib/realtime/index.ts
@@ -1,0 +1,286 @@
+export interface RealtimeSession {
+  url: string;
+  client_secret: {
+    value: string;
+  };
+  id?: string;
+  expires_at?: string;
+}
+
+export interface RealtimeClientOptions {
+  /**
+   * Endpoint to request session tokens from. Defaults to `/api/realtime/session`.
+   */
+  tokenEndpoint?: string;
+  /**
+   * Optional list of ICE servers to pass into the RTCPeerConnection.
+   */
+  iceServers?: RTCIceServer[];
+}
+
+export type RealtimeClientEvent =
+  | { type: "connection-state"; state: RTCPeerConnectionState }
+  | { type: "error"; error: Error }
+  | { type: "realtime-event"; payload: unknown; raw: string };
+
+type Listener<T> = (event: T) => void;
+
+class SimpleEventEmitter<T> {
+  private listeners = new Set<Listener<T>>();
+
+  subscribe(listener: Listener<T>) {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  emit(event: T) {
+    for (const listener of this.listeners) {
+      listener(event);
+    }
+  }
+
+  clear() {
+    this.listeners.clear();
+  }
+}
+
+function waitForIceGathering(connection: RTCPeerConnection) {
+  if (connection.iceGatheringState === "complete") {
+    return Promise.resolve();
+  }
+
+  return new Promise<void>((resolve) => {
+    const listener = () => {
+      if (connection.iceGatheringState === "complete") {
+        connection.removeEventListener("icegatheringstatechange", listener);
+        resolve();
+      }
+    };
+
+    connection.addEventListener("icegatheringstatechange", listener);
+  });
+}
+
+export class RealtimeClient {
+  readonly events = new SimpleEventEmitter<RealtimeClientEvent>();
+
+  private readonly tokenEndpoint: string;
+  private readonly iceServers?: RTCIceServer[];
+
+  private session: RealtimeSession | null = null;
+  private connection: RTCPeerConnection | null = null;
+  private dataChannel: RTCDataChannel | null = null;
+  private microphoneStream: MediaStream | null = null;
+  private microphoneSenders = new Set<RTCRtpSender>();
+  private remoteAudioElement: HTMLMediaElement | null = null;
+  private remoteAudioStream: MediaStream | null = null;
+
+  constructor(options?: RealtimeClientOptions) {
+    this.tokenEndpoint = options?.tokenEndpoint ?? "/api/realtime/session";
+    this.iceServers = options?.iceServers;
+  }
+
+  async connect() {
+    if (this.connection) {
+      return;
+    }
+
+    if (typeof window === "undefined") {
+      throw new Error("RealtimeClient can only be used in the browser");
+    }
+
+    const session = await this.fetchSession();
+    this.session = session;
+
+    const connection = new RTCPeerConnection({
+      iceServers: this.iceServers,
+    });
+
+    this.connection = connection;
+    connection.addEventListener("connectionstatechange", () => {
+      const state = connection.connectionState;
+      this.events.emit({ type: "connection-state", state });
+
+      if (state === "failed" || state === "disconnected" || state === "closed") {
+        this.disconnect();
+      }
+    });
+
+    connection.addEventListener("track", (event) => {
+      const [stream] = event.streams;
+      if (stream) {
+        this.remoteAudioStream = stream;
+        if (this.remoteAudioElement) {
+          this.remoteAudioElement.srcObject = stream;
+        }
+      }
+    });
+
+    const dataChannel = connection.createDataChannel("oai-events");
+    this.dataChannel = dataChannel;
+    dataChannel.addEventListener("message", (event) => {
+      if (typeof event.data !== "string") {
+        return;
+      }
+
+      let payload: unknown = event.data;
+      try {
+        payload = JSON.parse(event.data);
+      } catch {
+        // Keep raw payload when JSON parsing fails.
+      }
+
+      this.events.emit({ type: "realtime-event", payload, raw: event.data });
+    });
+
+    dataChannel.addEventListener("error", (event) => {
+      const error = event.error instanceof Error ? event.error : new Error("Data channel error");
+      this.events.emit({ type: "error", error });
+    });
+
+    try {
+      const offer = await connection.createOffer({ offerToReceiveAudio: true });
+      await connection.setLocalDescription(offer);
+      await waitForIceGathering(connection);
+
+      const localDescription = connection.localDescription;
+      if (!localDescription?.sdp) {
+        throw new Error("Local description missing during negotiation");
+      }
+
+      const response = await fetch(session.url, {
+        method: "POST",
+        body: localDescription.sdp,
+        headers: {
+          Authorization: `Bearer ${session.client_secret.value}`,
+          "Content-Type": "application/sdp",
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to negotiate session: ${response.statusText}`);
+      }
+
+      const answer = await response.text();
+      await connection.setRemoteDescription({ type: "answer", sdp: answer });
+    } catch (error) {
+      this.events.emit({ type: "error", error: error instanceof Error ? error : new Error(String(error)) });
+      this.disconnect();
+      throw error;
+    }
+  }
+
+  disconnect() {
+    if (this.dataChannel) {
+      try {
+        this.dataChannel.close();
+      } catch {
+        // ignore
+      }
+    }
+
+    this.dataChannel = null;
+
+    if (this.connection) {
+      try {
+        this.connection.close();
+      } catch {
+        // ignore
+      }
+    }
+
+    this.connection = null;
+    this.session = null;
+
+    this.stopMicrophone();
+
+    if (this.remoteAudioElement) {
+      this.remoteAudioElement.srcObject = null;
+    }
+
+    this.remoteAudioStream = null;
+  }
+
+  attachRemoteAudioElement(element: HTMLMediaElement) {
+    this.remoteAudioElement = element;
+    this.remoteAudioElement.autoplay = true;
+    this.remoteAudioElement.playsInline = true;
+
+    if (this.remoteAudioStream) {
+      this.remoteAudioElement.srcObject = this.remoteAudioStream;
+    }
+  }
+
+  async startMicrophone() {
+    if (!this.connection) {
+      throw new Error("Realtime connection has not been established yet");
+    }
+
+    if (this.microphoneStream) {
+      return this.microphoneStream;
+    }
+
+    const stream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        channelCount: 1,
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
+      },
+    });
+
+    this.microphoneStream = stream;
+
+    for (const track of stream.getTracks()) {
+      const sender = this.connection.addTrack(track, stream);
+      this.microphoneSenders.add(sender);
+    }
+
+    return stream;
+  }
+
+  stopMicrophone() {
+    if (this.microphoneStream) {
+      for (const track of this.microphoneStream.getTracks()) {
+        track.stop();
+      }
+    }
+
+    if (this.connection) {
+      for (const sender of this.microphoneSenders) {
+        try {
+          this.connection.removeTrack(sender);
+        } catch {
+          // ignore failures when the sender has already been removed
+        }
+      }
+    }
+
+    this.microphoneSenders.clear();
+    this.microphoneStream = null;
+  }
+
+  private async fetchSession(): Promise<RealtimeSession> {
+    const response = await fetch(this.tokenEndpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Unable to fetch realtime session: ${response.statusText}`);
+    }
+
+    const session = (await response.json()) as RealtimeSession;
+    if (!session?.url || !session?.client_secret?.value) {
+      throw new Error("Realtime session response is missing required fields");
+    }
+
+    return session;
+  }
+}
+
+export function createRealtimeClient(options?: RealtimeClientOptions) {
+  return new RealtimeClient(options);
+}


### PR DESCRIPTION
## Summary
- add a reusable realtime client that negotiates WebRTC sessions and streams microphone audio
- create a server-side `/api/realtime/session` endpoint with orchestration fallback for minting session tokens
- replace the studio transcript with a live voice chat panel that subscribes to realtime events and manages microphone controls

## Testing
- npm run lint *(fails: Next.js `next lint` does not accept `next.config.ts` in this project)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690eede31850832297f805d281aa213f)