### PR TITLE
Add reference asset APIs and reference library panel

### DIFF
--- a/src/app/api/assets/route.ts
+++ b/src/app/api/assets/route.ts
@@ -1,0 +1,101 @@
+import { Buffer } from "buffer";
+import { NextRequest, NextResponse } from "next/server";
+import {
+  createReferenceAsset,
+  getReferenceAsset,
+  listReferenceAssets,
+  recordAssetBinary,
+  serializeReferenceAsset,
+  updateReferenceAsset
+} from "@/lib/assets";
+import { getStorageProvider } from "@/lib/storage";
+
+export const runtime = "nodejs";
+
+export async function GET(request: NextRequest) {
+  const projectId = request.nextUrl.searchParams.get("projectId");
+  const assetId = request.nextUrl.searchParams.get("assetId");
+
+  if (assetId) {
+    const asset = getReferenceAsset(assetId);
+    if (!asset) {
+      return NextResponse.json({ error: "Asset not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ asset: serializeReferenceAsset(asset) });
+  }
+
+  const assets = listReferenceAssets(projectId);
+  return NextResponse.json({ assets: assets.map(serializeReferenceAsset) });
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  const { name, description, contentType, size, projectId, tags, sourceType, url } = body;
+
+  if (!name || !contentType || typeof size !== "number") {
+    return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+  }
+
+  const asset = createReferenceAsset({
+    name,
+    description,
+    contentType,
+    size,
+    projectId,
+    tags,
+    sourceType,
+    url
+  });
+
+  const storage = getStorageProvider();
+  const signedUpload = await storage.createSignedUpload({
+    assetId: asset.id,
+    contentType,
+    size,
+    projectId
+  });
+
+  return NextResponse.json({
+    asset: serializeReferenceAsset(asset),
+    upload: signedUpload
+  });
+}
+
+export async function PUT(request: NextRequest) {
+  const assetId = request.nextUrl.searchParams.get("assetId");
+  if (!assetId) {
+    return NextResponse.json({ error: "Missing assetId" }, { status: 400 });
+  }
+
+  const asset = getReferenceAsset(assetId);
+  if (!asset) {
+    return NextResponse.json({ error: "Asset not found" }, { status: 404 });
+  }
+
+  const contentType = request.headers.get("content-type") ?? asset.contentType;
+  const data = Buffer.from(await request.arrayBuffer());
+
+  const updated = recordAssetBinary(assetId, data, contentType);
+  if (!updated) {
+    return NextResponse.json({ error: "Unable to update asset" }, { status: 500 });
+  }
+
+  return NextResponse.json({ asset: serializeReferenceAsset(updated) });
+}
+
+export async function PATCH(request: NextRequest) {
+  const body = await request.json();
+  const { assetId, updates } = body;
+
+  if (!assetId || typeof updates !== "object") {
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+  }
+
+  const asset = updateReferenceAsset(assetId, updates);
+  if (!asset) {
+    return NextResponse.json({ error: "Asset not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ asset: serializeReferenceAsset(asset) });
+}

--- a/src/app/api/projects/[id]/assets/route.ts
+++ b/src/app/api/projects/[id]/assets/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  EntityAssetTargetType,
+  listEntityAssets,
+  serializeEntityAsset,
+  serializeReferenceAsset,
+  upsertEntityAsset,
+  getReferenceAsset,
+  listReferenceAssets
+} from "@/lib/assets";
+
+export const runtime = "nodejs";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const projectId = params.id;
+  const assets = listEntityAssets(projectId).map(serializeEntityAsset);
+  const references = listReferenceAssets(projectId).map(serializeReferenceAsset);
+
+  return NextResponse.json({
+    assets,
+    references
+  });
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const projectId = params.id;
+  const body = await request.json();
+  const { assetId, entityId, entityType, caption, order, isPrivate } = body;
+
+  if (!assetId || !entityId || !entityType) {
+    return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+  }
+
+  if (!getReferenceAsset(assetId)) {
+    return NextResponse.json({ error: "Asset not found" }, { status: 404 });
+  }
+
+  if (!isEntityTargetType(entityType)) {
+    return NextResponse.json({ error: "Invalid entity type" }, { status: 400 });
+  }
+
+  const entityAsset = upsertEntityAsset({
+    projectId,
+    assetId,
+    entityId,
+    entityType,
+    caption,
+    order,
+    isPrivate
+  });
+
+  return NextResponse.json({ asset: serializeEntityAsset(entityAsset) });
+}
+
+function isEntityTargetType(value: string): value is EntityAssetTargetType {
+  return value === "beat" || value === "scene";
+}

--- a/src/components/ReferenceLibraryPanel.tsx
+++ b/src/components/ReferenceLibraryPanel.tsx
@@ -1,0 +1,352 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ReferenceAsset } from "@/lib/assets";
+import { useScriptDocStore } from "@/lib/scriptDocStore";
+
+type ReferenceLibraryPanelProps = {
+  projectId: string;
+  className?: string;
+  title?: string;
+};
+
+type UploadingState = {
+  [assetId: string]: boolean;
+};
+
+type SelectionMap = {
+  [assetId: string]: string;
+};
+
+export function ReferenceLibraryPanel({
+  projectId,
+  className,
+  title = "Reference Library"
+}: ReferenceLibraryPanelProps) {
+  const {
+    beats,
+    scenes,
+    referenceAssets,
+    entityAssets,
+    setReferenceAssets,
+    setEntityAssets,
+    upsertReferenceAsset,
+    upsertEntityAsset
+  } = useScriptDocStore();
+  const [isDragging, setIsDragging] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [uploading, setUploading] = useState<UploadingState>({});
+  const [selection, setSelection] = useState<SelectionMap>({});
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const response = await fetch(`/api/projects/${projectId}/assets`);
+        if (!response.ok) {
+          throw new Error("Unable to load assets");
+        }
+        const payload = await response.json();
+        if (!cancelled) {
+          setReferenceAssets(payload.references ?? []);
+          setEntityAssets(payload.assets ?? []);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to fetch assets");
+        }
+      }
+    }
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId, setEntityAssets, setReferenceAssets]);
+
+  useEffect(() => {
+    const nextSelection: SelectionMap = {};
+    entityAssets.forEach((link) => {
+      nextSelection[link.assetId] = `${link.entityType}:${link.entityId}`;
+    });
+    setSelection(nextSelection);
+  }, [entityAssets]);
+
+  const handleDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragging(true);
+  }, []);
+
+  const handleDragLeave = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragging(false);
+  }, []);
+
+  const handleDrop = useCallback(
+    async (event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      setIsDragging(false);
+      const files = Array.from(event.dataTransfer.files);
+      if (files.length) {
+        await uploadFiles(files);
+      }
+    },
+    []
+  );
+
+  const uploadFiles = useCallback(
+    async (files: File[]) => {
+      setError(null);
+      for (const file of files) {
+        let currentAssetId: string | null = null;
+        try {
+          const basePayload = {
+            name: file.name,
+            description: undefined,
+            contentType: file.type || "application/octet-stream",
+            size: file.size,
+            projectId
+          };
+
+          const createResponse = await fetch("/api/assets", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(basePayload)
+          });
+
+          if (!createResponse.ok) {
+            throw new Error("Unable to create asset");
+          }
+
+          const createPayload = await createResponse.json();
+          const asset: ReferenceAsset = createPayload.asset;
+          const uploadInfo = createPayload.upload;
+
+          currentAssetId = asset.id;
+
+          upsertReferenceAsset(asset);
+          setUploading((current) => ({ ...current, [asset.id]: true }));
+
+          const uploadResponse = await fetch(uploadInfo.uploadUrl, {
+            method: uploadInfo.method,
+            headers: uploadInfo.headers,
+            body: file
+          });
+
+          if (!uploadResponse.ok) {
+            throw new Error("Upload failed");
+          }
+
+          const uploadPayload = await uploadResponse.json();
+          const updated: ReferenceAsset = uploadPayload.asset;
+          upsertReferenceAsset(updated);
+        } catch (err) {
+          setError(err instanceof Error ? err.message : "Upload failed");
+        } finally {
+          if (currentAssetId) {
+            const assetId = currentAssetId;
+            setUploading((current) => ({ ...current, [assetId]: false }));
+          }
+        }
+      }
+    },
+    [projectId, upsertReferenceAsset]
+  );
+
+  const handleFileInput = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      if (event.target.files) {
+        await uploadFiles(Array.from(event.target.files));
+        event.target.value = "";
+      }
+    },
+    [uploadFiles]
+  );
+
+  const entityIndex = useMemo(() => {
+    const map = new Map<string, string[]>();
+    entityAssets.forEach((asset) => {
+      const key = asset.assetId;
+      const current = map.get(key) ?? [];
+      current.push(`${asset.entityType}:${asset.entityId}`);
+      map.set(key, current);
+    });
+    return map;
+  }, [entityAssets]);
+
+  const handleTagSelection = useCallback(
+    async (assetId: string, value: string) => {
+      if (!value) {
+        return;
+      }
+
+      const [entityType, entityId] = value.split(":");
+      try {
+        const response = await fetch(`/api/projects/${projectId}/assets`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ assetId, entityType, entityId })
+        });
+
+        if (!response.ok) {
+          throw new Error("Unable to tag asset");
+        }
+
+        const payload = await response.json();
+        upsertEntityAsset(payload.asset);
+        setSelection((current) => ({ ...current, [assetId]: value }));
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Unable to tag asset");
+      }
+    },
+    [projectId, upsertEntityAsset]
+  );
+
+  const renderAssetCard = (asset: ReferenceAsset) => {
+    const isUploading = uploading[asset.id];
+    const linkedTargets = entityIndex.get(asset.id) ?? [];
+    const accessibleLabel = `${asset.name} asset thumbnail`;
+
+    return (
+      <div
+        key={asset.id}
+        className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-white/70 p-4 text-slate-900 shadow-glass backdrop-blur-xs transition-colors duration-200 dark:border-white/5 dark:bg-vs-panel dark:text-vs-accent"
+      >
+        <div
+          className="relative aspect-video overflow-hidden rounded-xl border border-white/10 shadow-glass dark:border-white/5"
+          style={{
+            backgroundImage: asset.thumbnailUrl ? `url(${asset.thumbnailUrl})` : asset.previewColor,
+            backgroundSize: asset.thumbnailUrl ? "cover" : "100%",
+            backgroundPosition: "center"
+          }}
+          aria-label={accessibleLabel}
+        >
+          <div className="absolute inset-0 bg-gradient-to-br from-white/55 via-white/20 to-white/5 mix-blend-luminosity dark:from-black/70 dark:via-black/55 dark:to-transparent" />
+          <div className="absolute inset-0 bg-black/35 dark:bg-black/45" />
+          <div className="relative flex h-full flex-col justify-end gap-1 p-4 text-sm text-white">
+            <p className="font-semibold tracking-tight">{asset.name}</p>
+            <p className="text-xs text-white/80">
+              {asset.contentType} · {Math.round(asset.size / 1024)} KB
+            </p>
+            <p className="text-xs uppercase tracking-[0.2em] text-white/70">{asset.status}</p>
+          </div>
+          {isUploading ? (
+            <div className="absolute inset-0 flex items-center justify-center bg-black/60 text-xs font-semibold uppercase tracking-widest text-white">
+              Uploading…
+            </div>
+          ) : null}
+        </div>
+        <div className="flex flex-wrap items-center gap-2 text-xs">
+          {linkedTargets.map((target) => {
+            const [type, entityId] = target.split(":");
+            const label =
+              type === "beat"
+                ? beats.find((beat) => beat.id === entityId)?.title ?? entityId
+                : scenes.find((scene) => scene.id === entityId)?.title ?? entityId;
+            return (
+              <span
+                key={`${asset.id}-${target}`}
+                className="rounded-full border border-white/20 bg-white/60 px-3 py-1 font-medium uppercase tracking-widest text-slate-900 backdrop-blur-xs dark:border-white/10 dark:bg-white/10 dark:text-vs-accent"
+              >
+                {type === "beat" ? "Beat" : "Scene"}: {label}
+              </span>
+            );
+          })}
+        </div>
+        <label className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-widest text-slate-700 dark:text-vs-accent-strong">
+          Tag asset
+          <select
+            className="w-full rounded-xl border border-white/20 bg-white/80 px-3 py-2 text-sm text-slate-900 shadow-inner outline-none transition focus:border-slate-400 dark:border-white/10 dark:bg-black/40 dark:text-vs-accent"
+            value={selection[asset.id] ?? ""}
+            onChange={(event) => handleTagSelection(asset.id, event.target.value)}
+          >
+            <option value="">Select beat or scene</option>
+            <optgroup label="Beats">
+              {beats.map((beat) => (
+                <option key={beat.id} value={`beat:${beat.id}`}>
+                  Beat · {beat.title}
+                </option>
+              ))}
+            </optgroup>
+            <optgroup label="Scenes">
+              {scenes.map((scene) => (
+                <option key={scene.id} value={`scene:${scene.id}`}>
+                  Scene · {scene.title}
+                </option>
+              ))}
+            </optgroup>
+          </select>
+        </label>
+      </div>
+    );
+  };
+
+  const handleBrowseClick = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  return (
+    <section
+      className={`flex flex-col gap-6 rounded-3xl border border-white/10 bg-white/75 p-6 text-slate-900 shadow-glass backdrop-blur-xs transition-colors duration-200 dark:border-white/5 dark:bg-vs-panel/90 dark:text-vs-accent ${className ?? ""}`}
+    >
+      <header className="flex flex-col gap-2">
+        <h2 className="text-lg font-semibold tracking-tight text-slate-900 dark:text-vs-accent">{title}</h2>
+        <p className="text-sm text-slate-600 dark:text-vs-accent-strong/80">
+          Drop reference images or videos to keep beats and scenes grounded in shared visuals.
+        </p>
+      </header>
+      <div
+        className={`flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-slate-400/40 bg-white/70 p-8 text-center text-slate-700 transition dark:border-white/20 dark:bg-black/30 dark:text-vs-accent ${
+          isDragging ? "border-slate-600/60 bg-white/90 dark:border-white/40 dark:bg-black/50" : ""
+        }`}
+        onDragEnter={handleDragOver}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        role="button"
+        tabIndex={0}
+        aria-label="Upload reference assets"
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            handleBrowseClick();
+          }
+        }}
+      >
+        <p className="text-sm font-semibold uppercase tracking-widest">Drag files here or click to upload</p>
+        <p className="text-xs text-slate-500 dark:text-vs-accent-strong/70">
+          Glassmorphic panels ensure 4.5:1 contrast in light and dark modes.
+        </p>
+        <button
+          type="button"
+          onClick={handleBrowseClick}
+          className="rounded-full border border-white/30 bg-white/80 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-slate-900 shadow-inner transition hover:border-slate-400 hover:bg-white/95 dark:border-white/20 dark:bg-white/10 dark:text-vs-accent dark:hover:border-white/40"
+        >
+          Browse Files
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          className="hidden"
+          onChange={handleFileInput}
+          aria-hidden
+        />
+      </div>
+      {error ? (
+        <p className="rounded-xl border border-red-400/60 bg-red-50/80 p-3 text-sm text-red-700 dark:border-red-400/40 dark:bg-red-950/40 dark:text-red-200">
+          {error}
+        </p>
+      ) : null}
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {referenceAssets.length ? referenceAssets.map(renderAssetCard) : (
+          <p className="rounded-2xl border border-white/10 bg-white/60 p-6 text-sm text-slate-600 backdrop-blur-xs dark:border-white/5 dark:bg-black/40 dark:text-vs-accent-strong/70">
+            No reference assets yet. Upload files to build your shared palette.
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -1,0 +1,217 @@
+import { Buffer } from "buffer";
+import { randomUUID } from "crypto";
+
+export type AssetSourceType = "upload" | "external";
+
+export type AssetStatus = "pending" | "ready";
+
+export interface ReferenceAsset {
+  id: string;
+  projectId: string | null;
+  name: string;
+  description?: string;
+  sourceType: AssetSourceType;
+  url: string;
+  thumbnailUrl: string | null;
+  previewColor: string;
+  contentType: string;
+  size: number;
+  tags: string[];
+  status: AssetStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type EntityAssetTargetType = "beat" | "scene";
+
+export interface EntityAsset {
+  id: string;
+  projectId: string;
+  assetId: string;
+  entityId: string;
+  entityType: EntityAssetTargetType;
+  caption?: string;
+  order: number;
+  isPrivate: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface StoredAssetBinary {
+  data: string;
+  contentType: string;
+  size: number;
+}
+
+const referenceAssets = new Map<string, ReferenceAsset>();
+const entityAssets = new Map<string, EntityAsset>();
+const assetBinary = new Map<string, StoredAssetBinary>();
+
+const fallbackThumbnails = [
+  "linear-gradient(135deg, rgba(15,15,18,0.92), rgba(39,39,42,0.88))",
+  "linear-gradient(135deg, rgba(24,24,27,0.9), rgba(63,63,70,0.82))",
+  "linear-gradient(135deg, rgba(9,9,11,0.95), rgba(36,36,40,0.85))"
+];
+
+function computePreviewColor(id: string): string {
+  const hash = id.split("").reduce((acc, char) => acc + char.charCodeAt(0), 0);
+  return fallbackThumbnails[hash % fallbackThumbnails.length];
+}
+
+export interface CreateReferenceAssetInput {
+  name: string;
+  projectId?: string | null;
+  description?: string;
+  contentType: string;
+  size: number;
+  tags?: string[];
+  sourceType?: AssetSourceType;
+  url?: string;
+}
+
+export interface CreateEntityAssetInput {
+  projectId: string;
+  assetId: string;
+  entityId: string;
+  entityType: EntityAssetTargetType;
+  caption?: string;
+  isPrivate?: boolean;
+  order?: number;
+}
+
+export function listReferenceAssets(projectId?: string | null): ReferenceAsset[] {
+  const values = Array.from(referenceAssets.values());
+  if (!projectId) {
+    return values;
+  }
+
+  return values.filter((asset) => asset.projectId === projectId || asset.projectId === null);
+}
+
+export function getReferenceAsset(assetId: string): ReferenceAsset | undefined {
+  return referenceAssets.get(assetId);
+}
+
+export function createReferenceAsset(input: CreateReferenceAssetInput): ReferenceAsset {
+  const id = randomUUID();
+  const now = new Date().toISOString();
+  const asset: ReferenceAsset = {
+    id,
+    projectId: input.projectId ?? null,
+    name: input.name,
+    description: input.description,
+    sourceType: input.sourceType ?? (input.url ? "external" : "upload"),
+    url: input.url ?? "",
+    thumbnailUrl: null,
+    previewColor: computePreviewColor(id),
+    contentType: input.contentType,
+    size: input.size,
+    tags: input.tags ?? [],
+    status: "pending",
+    createdAt: now,
+    updatedAt: now
+  };
+
+  referenceAssets.set(id, asset);
+  return asset;
+}
+
+export function updateReferenceAsset(assetId: string, updates: Partial<ReferenceAsset>): ReferenceAsset | undefined {
+  const existing = referenceAssets.get(assetId);
+  if (!existing) {
+    return undefined;
+  }
+
+  const updated: ReferenceAsset = {
+    ...existing,
+    ...updates,
+    updatedAt: new Date().toISOString()
+  };
+
+  referenceAssets.set(assetId, updated);
+  return updated;
+}
+
+export function recordAssetBinary(assetId: string, data: Buffer, contentType: string): ReferenceAsset | undefined {
+  const existing = referenceAssets.get(assetId);
+  if (!existing) {
+    return undefined;
+  }
+
+  const encoded = `data:${contentType};base64,${data.toString("base64")}`;
+  assetBinary.set(assetId, {
+    data: encoded,
+    contentType,
+    size: data.byteLength
+  });
+
+  const asset = updateReferenceAsset(assetId, {
+    status: "ready",
+    url: existing.url || encoded,
+    thumbnailUrl: encoded,
+    contentType,
+    size: data.byteLength
+  });
+
+  return asset;
+}
+
+export function listEntityAssets(projectId: string): EntityAsset[] {
+  return Array.from(entityAssets.values()).filter((item) => item.projectId === projectId);
+}
+
+export function createEntityAsset(input: CreateEntityAssetInput): EntityAsset {
+  const id = randomUUID();
+  const now = new Date().toISOString();
+  const entity: EntityAsset = {
+    id,
+    projectId: input.projectId,
+    assetId: input.assetId,
+    entityId: input.entityId,
+    entityType: input.entityType,
+    caption: input.caption,
+    order: input.order ?? 0,
+    isPrivate: input.isPrivate ?? false,
+    createdAt: now,
+    updatedAt: now
+  };
+
+  entityAssets.set(id, entity);
+  return entity;
+}
+
+export function findEntityAsset(assetId: string, entityId: string, entityType: EntityAssetTargetType): EntityAsset | undefined {
+  return Array.from(entityAssets.values()).find(
+    (item) => item.assetId === assetId && item.entityId === entityId && item.entityType === entityType
+  );
+}
+
+export function upsertEntityAsset(input: CreateEntityAssetInput): EntityAsset {
+  const existing = findEntityAsset(input.assetId, input.entityId, input.entityType);
+  if (existing) {
+    const updated: EntityAsset = {
+      ...existing,
+      caption: input.caption ?? existing.caption,
+      order: input.order ?? existing.order,
+      isPrivate: input.isPrivate ?? existing.isPrivate,
+      updatedAt: new Date().toISOString()
+    };
+
+    entityAssets.set(existing.id, updated);
+    return updated;
+  }
+
+  return createEntityAsset(input);
+}
+
+export function serializeReferenceAsset(asset: ReferenceAsset) {
+  return {
+    ...asset
+  };
+}
+
+export function serializeEntityAsset(asset: EntityAsset) {
+  return {
+    ...asset
+  };
+}

--- a/src/lib/scriptDocStore.tsx
+++ b/src/lib/scriptDocStore.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { createContext, useContext, useMemo, useState } from "react";
+import type { EntityAsset, ReferenceAsset } from "@/lib/assets";
+
+type Beat = {
+  id: string;
+  title: string;
+  summary?: string;
+};
+
+type Scene = {
+  id: string;
+  title: string;
+  summary?: string;
+};
+
+type ScriptDocStoreState = {
+  beats: Beat[];
+  scenes: Scene[];
+  referenceAssets: ReferenceAsset[];
+  entityAssets: EntityAsset[];
+};
+
+type ScriptDocStoreActions = {
+  setReferenceAssets: (assets: ReferenceAsset[]) => void;
+  upsertReferenceAsset: (asset: ReferenceAsset) => void;
+  setEntityAssets: (assets: EntityAsset[]) => void;
+  upsertEntityAsset: (asset: EntityAsset) => void;
+};
+
+type ScriptDocStore = ScriptDocStoreState & ScriptDocStoreActions;
+
+const ScriptDocContext = createContext<ScriptDocStore | undefined>(undefined);
+
+const defaultBeats: Beat[] = [
+  { id: "beat-1", title: "Inciting Spark" },
+  { id: "beat-2", title: "Rising Tension" }
+];
+
+const defaultScenes: Scene[] = [
+  { id: "scene-1", title: "Opening Control Room" },
+  { id: "scene-2", title: "Field Deployment" }
+];
+
+type ProviderProps = {
+  children: React.ReactNode;
+  initialBeats?: Beat[];
+  initialScenes?: Scene[];
+};
+
+export function ScriptDocProvider({
+  children,
+  initialBeats,
+  initialScenes
+}: ProviderProps) {
+  const [referenceAssets, setReferenceAssets] = useState<ReferenceAsset[]>([]);
+  const [entityAssets, setEntityAssets] = useState<EntityAsset[]>([]);
+
+  const beats = initialBeats ?? defaultBeats;
+  const scenes = initialScenes ?? defaultScenes;
+
+  const value = useMemo<ScriptDocStore>(
+    () => ({
+      beats,
+      scenes,
+      referenceAssets,
+      entityAssets,
+      setReferenceAssets: (assets) => setReferenceAssets([...assets]),
+      upsertReferenceAsset: (asset) => {
+        setReferenceAssets((current) => {
+          const existing = current.find((item) => item.id === asset.id);
+          if (existing) {
+            return current.map((item) => (item.id === asset.id ? asset : item));
+          }
+          return [...current, asset];
+        });
+      },
+      setEntityAssets: (assets) => setEntityAssets([...assets]),
+      upsertEntityAsset: (asset) => {
+        setEntityAssets((current) => {
+          const existing = current.find((item) => item.id === asset.id);
+          if (existing) {
+            return current.map((item) => (item.id === asset.id ? asset : item));
+          }
+          return [...current, asset];
+        });
+      }
+    }),
+    [beats, scenes, referenceAssets, entityAssets]
+  );
+
+  return <ScriptDocContext.Provider value={value}>{children}</ScriptDocContext.Provider>;
+}
+
+export function useScriptDocStore() {
+  const context = useContext(ScriptDocContext);
+  if (!context) {
+    throw new Error("useScriptDocStore must be used within a ScriptDocProvider");
+  }
+
+  return context;
+}

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,47 @@
+export interface SignedUpload {
+  uploadUrl: string;
+  method: "PUT" | "POST";
+  headers: Record<string, string>;
+  assetUrl: string;
+  expiresAt: string;
+}
+
+export interface StorageProvider {
+  createSignedUpload(input: {
+    assetId: string;
+    contentType: string;
+    size: number;
+    projectId?: string | null;
+  }): Promise<SignedUpload>;
+}
+
+class LocalStorageProvider implements StorageProvider {
+  async createSignedUpload({ assetId, contentType }: {
+    assetId: string;
+    contentType: string;
+    size: number;
+    projectId?: string | null;
+  }): Promise<SignedUpload> {
+    const expires = new Date(Date.now() + 5 * 60 * 1000);
+
+    return {
+      uploadUrl: `/api/assets?assetId=${assetId}`,
+      method: "PUT",
+      headers: {
+        "Content-Type": contentType
+      },
+      assetUrl: `/api/assets/${assetId}`,
+      expiresAt: expires.toISOString()
+    };
+  }
+}
+
+let provider: StorageProvider | null = null;
+
+export function getStorageProvider(): StorageProvider {
+  if (!provider) {
+    provider = new LocalStorageProvider();
+  }
+
+  return provider;
+}


### PR DESCRIPTION
## Summary
- implement an in-memory reference asset store with a storage abstraction for signed uploads
- add `/api/assets` and `/api/projects/:id/assets` routes to manage reference assets and their beat/scene links
- create a ReferenceLibraryPanel UI backed by the ScriptDoc store with drag-and-drop uploads, tagging, and glassmorphic styling

## Testing
- npm run lint *(fails: Next.js CLI refuses `next.config.ts` when running lint)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690eea816d1883228d7ed1e36c1493fc)