### PR TITLE
Add reduced motion support to AnimatedHeadline

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "next": "14.2.11",
@@ -17,11 +18,15 @@
     "@types/node": "20.14.15",
     "@types/react": "18.3.5",
     "@types/react-dom": "18.3.0",
+    "@testing-library/jest-dom": "6.4.6",
+    "@testing-library/react": "16.0.1",
     "autoprefixer": "10.4.20",
     "eslint": "8.57.0",
     "eslint-config-next": "14.2.11",
+    "jsdom": "24.1.1",
     "postcss": "8.4.41",
     "tailwindcss": "3.4.13",
-    "typescript": "5.5.4"
+    "typescript": "5.5.4",
+    "vitest": "2.1.1"
   }
 }

--- a/src/components/AnimatedHeadline.test.tsx
+++ b/src/components/AnimatedHeadline.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { AnimatedHeadline } from "./AnimatedHeadline";
+
+const originalMatchMedia = window.matchMedia;
+
+function mockMatchMedia(matches: boolean) {
+  const listeners = new Set<EventListener>();
+
+  const mediaQuery: MediaQueryList = {
+    matches,
+    media: "(prefers-reduced-motion: reduce)",
+    onchange: null,
+    addEventListener: (_: string, listener: EventListener | EventListenerObject | null) => {
+      if (listener) {
+        listeners.add(listener as EventListener);
+      }
+    },
+    removeEventListener: (_: string, listener: EventListener | EventListenerObject | null) => {
+      if (listener) {
+        listeners.delete(listener as EventListener);
+      }
+    },
+    addListener: (listener: EventListener) => {
+      listeners.add(listener);
+    },
+    removeListener: (listener: EventListener) => {
+      listeners.delete(listener);
+    },
+    dispatchEvent: () => true,
+  };
+
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation(() => mediaQuery),
+  });
+}
+
+describe("AnimatedHeadline", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: originalMatchMedia,
+    });
+  });
+
+  test("renders animated phrases and interval when motion is allowed", () => {
+    mockMatchMedia(false);
+    vi.useFakeTimers();
+    const setIntervalSpy = vi.spyOn(window, "setInterval");
+
+    render(<AnimatedHeadline phrases={["One", "Two", "Three"]} />);
+
+    expect(screen.getByTestId("animated-headline")).toHaveAttribute("data-motion", "enabled");
+    expect(screen.queryByTestId("static-phrase")).not.toBeInTheDocument();
+    expect(screen.getAllByTestId("animated-phrase")).toHaveLength(3);
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("short-circuits animation when reduced motion is preferred", async () => {
+    mockMatchMedia(true);
+    const setIntervalSpy = vi.spyOn(window, "setInterval");
+
+    render(<AnimatedHeadline phrases={["Quiet", "Calm"]} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("animated-headline")).toHaveAttribute("data-motion", "reduced");
+    });
+
+    expect(screen.getByTestId("static-phrase")).toHaveTextContent("Quiet");
+    expect(screen.queryAllByTestId("animated-phrase")).toHaveLength(0);
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/AnimatedHeadline.tsx
+++ b/src/components/AnimatedHeadline.tsx
@@ -11,9 +11,42 @@ interface AnimatedHeadlineProps {
 export function AnimatedHeadline({ phrases }: AnimatedHeadlineProps) {
   const safePhrases = useMemo(() => (phrases.length ? phrases : [""]), [phrases]);
   const [index, setIndex] = useState(0);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState<boolean | null>(null);
 
   useEffect(() => {
-    if (safePhrases.length <= 1) {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      setPrefersReducedMotion(false);
+      return;
+    }
+
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+
+    const handleChange = (event: MediaQueryListEvent | MediaQueryList) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    handleChange(mediaQuery);
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", handleChange);
+      return () => {
+        mediaQuery.removeEventListener("change", handleChange);
+      };
+    }
+
+    if (typeof mediaQuery.addListener === "function") {
+      mediaQuery.addListener(handleChange);
+
+      return () => {
+        mediaQuery.removeListener(handleChange);
+      };
+    }
+
+    return () => {};
+  }, []);
+
+  useEffect(() => {
+    if (prefersReducedMotion !== false || safePhrases.length <= 1) {
       return;
     }
 
@@ -24,21 +57,39 @@ export function AnimatedHeadline({ phrases }: AnimatedHeadlineProps) {
     return () => {
       window.clearInterval(timer);
     };
-  }, [safePhrases.length]);
+  }, [prefersReducedMotion, safePhrases.length]);
+
+  const shouldReduceMotion = prefersReducedMotion === true;
+  const visiblePhraseIndex = shouldReduceMotion ? 0 : index;
+  const visiblePhrase = safePhrases[visiblePhraseIndex];
 
   return (
-    <span className="relative inline-flex h-[1.4em] overflow-hidden align-middle text-gradient-sheen">
-      {safePhrases.map((phrase, phraseIndex) => (
+    <span
+      className="relative inline-flex h-[1.4em] overflow-hidden align-middle text-gradient-sheen"
+      data-motion={shouldReduceMotion ? "reduced" : "enabled"}
+      data-testid="animated-headline"
+    >
+      {shouldReduceMotion ? (
         <span
-          key={phrase}
-          className={`absolute inset-x-0 text-balance text-left text-3xl font-medium tracking-tight transition-all duration-700 ease-out md:text-5xl ${
-            phraseIndex === index ? "translate-y-0 opacity-100" : "translate-y-full opacity-0"
-          }`}
+          className="text-balance text-left text-3xl font-medium tracking-tight md:text-5xl"
+          data-testid="static-phrase"
         >
-          {phrase}
+          {visiblePhrase}
         </span>
-      ))}
-      <span className="invisible text-3xl md:text-5xl">{safePhrases[index]}</span>
+      ) : (
+        safePhrases.map((phrase, phraseIndex) => (
+          <span
+            key={phrase}
+            className={`absolute inset-x-0 text-balance text-left text-3xl font-medium tracking-tight transition-all duration-700 ease-out md:text-5xl ${
+              phraseIndex === index ? "translate-y-0 opacity-100" : "translate-y-full opacity-0"
+            }`}
+            data-testid="animated-phrase"
+          >
+            {phrase}
+          </span>
+        ))
+      )}
+      <span className="invisible text-3xl md:text-5xl">{visiblePhrase}</span>
     </span>
   );
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./vitest.setup.ts"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";


### PR DESCRIPTION
## Summary
- detect the prefers-reduced-motion setting in `AnimatedHeadline` and avoid scheduling the rotation timer when motion should be minimized
- render a static, non-animated headline when reduced motion is requested while keeping the existing animated experience otherwise
- configure Vitest with Testing Library coverage and add unit tests that exercise both motion-enabled and reduced-motion variants

## Testing
- npm run test -- --run *(fails: `vitest` binary unavailable because new dev dependencies cannot be installed in this offline environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690efd253e3883228f38255c614d4282)