### PR TITLE
Improve resiliency of marketing content fetching

### DIFF
--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -4,13 +4,23 @@ import { GlassCard } from "@/components/GlassCard";
 import { SectionHeader } from "@/components/SectionHeader";
 import { fetchFaqContent } from "@/lib/http";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 600;
 
 export default async function FAQPage() {
-  const faq = await fetchFaqContent();
+  const faqResult = await fetchFaqContent();
+  const faq = faqResult.data;
+  const showFallbackNotice = faqResult.source === "fallback";
 
   return (
     <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-20 px-6 py-16 md:px-10">
+      {showFallbackNotice ? (
+        <div
+          role="status"
+          className="rounded-3xl border border-amber-400/30 bg-amber-500/10 px-6 py-4 text-sm text-amber-100"
+        >
+          We’re serving archived FAQ details while the live service recovers.
+        </div>
+      ) : null}
       <header className="space-y-10">
         <SectionHeader
           alignment="left"
@@ -34,13 +44,27 @@ export default async function FAQPage() {
           title="What powers each session?"
           description="Four feature pillars handle intake, drafting, reference management, and delivery without overwhelming the interface."
         />
-        <div className="grid gap-6 md:grid-cols-2">
-          {faq.coreFeatures.map((feature) => (
-            <GlassCard key={feature.slug} id={feature.slug} title={feature.title}>
-              <p>{feature.description}</p>
-            </GlassCard>
-          ))}
-        </div>
+        {faq.coreFeatures?.length ? (
+          <div className="grid gap-6 md:grid-cols-2">
+            {faq.coreFeatures.map((feature) => (
+              <GlassCard key={feature.slug} id={feature.slug} title={feature.title}>
+                <p>{feature.description}</p>
+              </GlassCard>
+            ))}
+          </div>
+        ) : (
+          <div className="grid gap-6 md:grid-cols-2">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <div
+                key={`core-feature-skeleton-${index}`}
+                className="rounded-3xl border border-white/10 bg-white/5 p-6"
+              >
+                <div className="h-4 w-1/2 animate-pulse rounded bg-white/10" />
+                <div className="mt-4 h-20 animate-pulse rounded bg-white/5" />
+              </div>
+            ))}
+          </div>
+        )}
       </section>
 
       <section className="space-y-10">
@@ -50,13 +74,27 @@ export default async function FAQPage() {
           title="How does the flow feel after login?"
           description="The studio canvas opens to a voice-ready control room. These stages surface progressively so the workspace stays calm."
         />
-        <div className="grid gap-6 md:grid-cols-2">
-          {faq.workflowStages.map((stage) => (
-            <GlassCard key={stage.slug} id={stage.slug} title={stage.title} subtitle={stage.label} accent="dim">
-              <p>{stage.description}</p>
-            </GlassCard>
-          ))}
-        </div>
+        {faq.workflowStages?.length ? (
+          <div className="grid gap-6 md:grid-cols-2">
+            {faq.workflowStages.map((stage) => (
+              <GlassCard key={stage.slug} id={stage.slug} title={stage.title} subtitle={stage.label} accent="dim">
+                <p>{stage.description}</p>
+              </GlassCard>
+            ))}
+          </div>
+        ) : (
+          <div className="grid gap-6 md:grid-cols-2">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <div
+                key={`workflow-skeleton-${index}`}
+                className="rounded-3xl border border-white/10 bg-white/5 p-6"
+              >
+                <div className="h-4 w-1/3 animate-pulse rounded bg-white/10" />
+                <div className="mt-4 h-16 animate-pulse rounded bg-white/5" />
+              </div>
+            ))}
+          </div>
+        )}
       </section>
 
       <section className="space-y-10">
@@ -66,17 +104,35 @@ export default async function FAQPage() {
           title="Under the hood"
           description="Script Speech combines realtime voice processing, orchestrated AI agents, and reference management."
         />
-        <div className="grid gap-6 md:grid-cols-3">
-          {faq.platformPillars.map((pillar) => (
-            <GlassCard key={pillar.slug} id={pillar.slug} title={pillar.title}>
-              <ul className="space-y-2 text-sm text-zinc-300/90 md:text-base">
-                {pillar.points.map((point) => (
-                  <li key={point}>{point}</li>
-                ))}
-              </ul>
-            </GlassCard>
-          ))}
-        </div>
+        {faq.platformPillars?.length ? (
+          <div className="grid gap-6 md:grid-cols-3">
+            {faq.platformPillars.map((pillar) => (
+              <GlassCard key={pillar.slug} id={pillar.slug} title={pillar.title}>
+                <ul className="space-y-2 text-sm text-zinc-300/90 md:text-base">
+                  {pillar.points.map((point) => (
+                    <li key={point}>{point}</li>
+                  ))}
+                </ul>
+              </GlassCard>
+            ))}
+          </div>
+        ) : (
+          <div className="grid gap-6 md:grid-cols-3">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <div
+                key={`pillar-skeleton-${index}`}
+                className="rounded-3xl border border-white/10 bg-white/5 p-6"
+              >
+                <div className="h-4 w-2/3 animate-pulse rounded bg-white/10" />
+                <div className="mt-4 space-y-3">
+                  {Array.from({ length: 3 }).map((__, idx) => (
+                    <div key={idx} className="h-3 w-full animate-pulse rounded bg-white/5" />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </section>
 
       <footer className="space-y-6 border-t border-white/10 pt-10 text-sm text-zinc-500">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,19 +4,32 @@ import { AccessRequestForm } from "@/components/AccessRequestForm";
 import { AnimatedHeadline } from "@/components/AnimatedHeadline";
 import { fetchFaqContent, fetchLandingContent } from "@/lib/http";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 600;
 
 export default async function HomePage() {
-  const [landing, faq] = await Promise.all([fetchLandingContent(), fetchFaqContent()]);
+  const [landingResult, faqResult] = await Promise.all([fetchLandingContent(), fetchFaqContent()]);
+  const landing = landingResult.data;
+  const faq = faqResult.data;
 
-  const footnotes = faq.coreFeatures.map((feature, index) => ({
+  const features = faq.coreFeatures ?? [];
+  const footnotes = features.map((feature, index) => ({
     number: index + 1,
     title: feature.title,
     href: `/faq#${feature.slug}`,
   }));
+  const heroFootnote = footnotes[2];
+  const showFallbackNotice = landingResult.source === "fallback" || faqResult.source === "fallback";
 
   return (
     <main className="mx-auto flex min-h-screen max-w-6xl flex-col gap-24 px-6 py-16 md:px-10">
+      {showFallbackNotice ? (
+        <div
+          role="status"
+          className="rounded-3xl border border-amber-400/30 bg-amber-500/10 px-6 py-4 text-sm text-amber-100"
+        >
+          We’re sharing a saved snapshot of our marketing content while the live service is unavailable.
+        </div>
+      ) : null}
       <header className="grain-overlay relative overflow-hidden rounded-[3rem] border border-white/10 bg-vs-panel px-10 py-16 shadow-glow backdrop-blur-2xl md:px-16 md:py-24">
         <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.08),_transparent_55%)]" />
         <div className="flex flex-col gap-8">
@@ -61,7 +74,7 @@ export default async function HomePage() {
           <p className="text-pretty text-base text-zinc-300/90 md:text-lg">
             Direct the session with voice and keep typing in reach for surgical edits. The interface is monochrome on purpose—your story, waveforms, and references are the only elements in motion. Scene boards and exports remain tucked away until you summon them
             <sup className="ml-1 text-sm align-super text-zinc-400">
-              <Link href={footnotes[2].href}>{footnotes[2].number}</Link>
+              <Link href={heroFootnote?.href ?? "#"}>{heroFootnote?.number ?? "—"}</Link>
             </sup>
             .
           </p>
@@ -70,38 +83,65 @@ export default async function HomePage() {
           </p>
         </div>
         <div className="grid gap-6">
-          {landing.vignettes.map((item) => (
-            <div
-              key={item.title}
-              className="group rounded-3xl border border-white/10 bg-white/5 p-6 transition-all duration-300 hover:border-white/30 hover:bg-white/10"
-            >
-              <div className="flex items-start justify-between">
-                <p className="text-lg font-semibold text-white">{item.title}</p>
-                <Link href={footnotes[item.footnote - 1].href} className="text-sm text-zinc-400 transition-colors group-hover:text-white">
-                  {item.footnote}
-                </Link>
-              </div>
-              <p className="mt-3 text-sm text-zinc-400 md:text-base">{item.description}</p>
-            </div>
-          ))}
+          {landing.vignettes?.length
+            ? landing.vignettes.map((item) => (
+                <div
+                  key={item.title}
+                  className="group rounded-3xl border border-white/10 bg-white/5 p-6 transition-all duration-300 hover:border-white/30 hover:bg-white/10"
+                >
+                  <div className="flex items-start justify-between">
+                    <p className="text-lg font-semibold text-white">{item.title}</p>
+                    <Link
+                      href={footnotes[item.footnote - 1]?.href ?? "#"}
+                      className="text-sm text-zinc-400 transition-colors group-hover:text-white"
+                    >
+                      {item.footnote}
+                    </Link>
+                  </div>
+                  <p className="mt-3 text-sm text-zinc-400 md:text-base">{item.description}</p>
+                </div>
+              ))
+            : Array.from({ length: 3 }).map((_, index) => (
+                <div
+                  key={`vignette-skeleton-${index}`}
+                  className="rounded-3xl border border-white/10 bg-white/5 p-6"
+                >
+                  <div className="h-5 w-1/2 animate-pulse rounded bg-white/10" />
+                  <div className="mt-4 h-20 animate-pulse rounded bg-white/5" />
+                </div>
+              ))}
         </div>
       </section>
 
       <section className="space-y-10">
         <h2 className="text-balance text-3xl font-semibold text-white md:text-4xl">How a session flows once you log in</h2>
         <div className="grid gap-6 md:grid-cols-3">
-          {landing.cadence.map((step) => (
-            <div
-              key={step.heading}
-              className="rounded-3xl border border-white/10 bg-white/5 p-6 transition-transform duration-300 hover:-translate-y-1"
-            >
-              <p className="text-sm uppercase tracking-[0.3em] text-zinc-400">{step.heading}</p>
-              <p className="mt-4 text-pretty text-base text-zinc-300/90">{step.body}</p>
-              <Link href={footnotes[step.anchor - 1].href} className="mt-6 inline-flex text-sm text-zinc-400 hover:text-white">
-                Learn more ↗
-              </Link>
-            </div>
-          ))}
+          {landing.cadence?.length
+            ? landing.cadence.map((step) => (
+                <div
+                  key={step.heading}
+                  className="rounded-3xl border border-white/10 bg-white/5 p-6 transition-transform duration-300 hover:-translate-y-1"
+                >
+                  <p className="text-sm uppercase tracking-[0.3em] text-zinc-400">{step.heading}</p>
+                  <p className="mt-4 text-pretty text-base text-zinc-300/90">{step.body}</p>
+                  <Link
+                    href={footnotes[step.anchor - 1]?.href ?? "#"}
+                    className="mt-6 inline-flex text-sm text-zinc-400 hover:text-white"
+                  >
+                    Learn more ↗
+                  </Link>
+                </div>
+              ))
+            : Array.from({ length: 3 }).map((_, index) => (
+                <div
+                  key={`cadence-skeleton-${index}`}
+                  className="rounded-3xl border border-white/10 bg-white/5 p-6"
+                >
+                  <div className="h-3 w-1/3 animate-pulse rounded bg-white/10" />
+                  <div className="mt-4 h-16 animate-pulse rounded bg-white/5" />
+                  <div className="mt-6 h-4 w-20 animate-pulse rounded bg-white/10" />
+                </div>
+              ))}
         </div>
       </section>
 
@@ -136,16 +176,22 @@ export default async function HomePage() {
             View the FAQ dossier
           </Link>
         </div>
-        <ol className="grid gap-3 md:grid-cols-2">
-          {footnotes.map((note) => (
-            <li key={note.number} className="flex items-baseline gap-3 rounded-2xl border border-white/5 bg-white/5 px-4 py-3">
-              <span className="text-xs font-semibold text-white/70">[{note.number}]</span>
-              <Link href={note.href} className="text-sm text-zinc-300 hover:text-white">
-                {note.title}
-              </Link>
-            </li>
-          ))}
-        </ol>
+        {footnotes.length ? (
+          <ol className="grid gap-3 md:grid-cols-2">
+            {footnotes.map((note) => (
+              <li key={note.number} className="flex items-baseline gap-3 rounded-2xl border border-white/5 bg-white/5 px-4 py-3">
+                <span className="text-xs font-semibold text-white/70">[{note.number}]</span>
+                <Link href={note.href} className="text-sm text-zinc-300 hover:text-white">
+                  {note.title}
+                </Link>
+              </li>
+            ))}
+          </ol>
+        ) : (
+          <div className="rounded-2xl border border-white/5 bg-white/5 px-4 py-6">
+            <p className="text-sm text-zinc-400">Footnotes are temporarily unavailable. Please check back soon.</p>
+          </div>
+        )}
       </footer>
     </main>
   );

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -9,13 +9,23 @@ const previewPhrases = [
   "Footnote-led feature dossier",
 ];
 
-export const dynamic = "force-dynamic";
+export const revalidate = 600;
 
 export default async function PreviewPage() {
-  const faq = await fetchFaqContent();
+  const faqResult = await fetchFaqContent();
+  const faq = faqResult.data;
+  const showFallbackNotice = faqResult.source === "fallback";
 
   return (
     <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-16 px-6 py-16 md:px-10">
+      {showFallbackNotice ? (
+        <div
+          role="status"
+          className="rounded-3xl border border-amber-400/30 bg-amber-500/10 px-6 py-4 text-sm text-amber-100"
+        >
+          We’re showing cached highlights while the live preview content reloads.
+        </div>
+      ) : null}
       <header className="space-y-8">
         <p className="text-xs uppercase tracking-[0.35em] text-zinc-500">Preview</p>
         <div className="space-y-6">
@@ -41,13 +51,27 @@ export default async function PreviewPage() {
       </header>
 
       <section className="grid gap-6 md:grid-cols-2">
-        {faq.coreFeatures.slice(0, 4).map((feature, index) => (
-          <div key={feature.slug} className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-glass backdrop-blur transition hover:border-white/25 hover:bg-white/10">
-            <p className="text-xs uppercase tracking-[0.35em] text-zinc-500">Feature {index + 1}</p>
-            <h2 className="mt-3 text-lg font-semibold text-white">{feature.title}</h2>
-            <p className="mt-3 text-sm text-zinc-300">{feature.description}</p>
-          </div>
-        ))}
+        {faq.coreFeatures?.length
+          ? faq.coreFeatures.slice(0, 4).map((feature, index) => (
+              <div
+                key={feature.slug}
+                className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-glass backdrop-blur transition hover:border-white/25 hover:bg-white/10"
+              >
+                <p className="text-xs uppercase tracking-[0.35em] text-zinc-500">Feature {index + 1}</p>
+                <h2 className="mt-3 text-lg font-semibold text-white">{feature.title}</h2>
+                <p className="mt-3 text-sm text-zinc-300">{feature.description}</p>
+              </div>
+            ))
+          : Array.from({ length: 4 }).map((_, index) => (
+              <div
+                key={`preview-feature-skeleton-${index}`}
+                className="rounded-3xl border border-white/10 bg-white/5 p-6"
+              >
+                <div className="h-3 w-1/3 animate-pulse rounded bg-white/10" />
+                <div className="mt-4 h-5 w-2/3 animate-pulse rounded bg-white/10" />
+                <div className="mt-4 h-16 animate-pulse rounded bg-white/5" />
+              </div>
+            ))}
       </section>
 
       <section className="grid gap-6 md:grid-cols-2">

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -2,6 +2,18 @@ import type { FAQContent } from "@/lib/siteData";
 import type { LandingContent } from "@/data/landing";
 import { headers } from "next/headers";
 
+import { getFaqContent, getLandingContent } from "@/lib/siteData";
+
+type NextFetchInit = RequestInit & { next?: { revalidate?: number } };
+
+type MarketingFetchResult<T> = {
+  data: T;
+  error?: Error;
+  source: "remote" | "fallback";
+};
+
+const MARKETING_REVALIDATE_SECONDS = 60 * 10; // 10 minutes
+
 function resolveBaseUrl() {
   const headerList = headers();
   const forwardedProto = headerList.get("x-forwarded-proto");
@@ -23,28 +35,82 @@ function resolveBaseUrl() {
   return `http://localhost:${port}`;
 }
 
-async function fetchFromApi<T>(path: string, init?: RequestInit) {
+async function fetchFromApi<T>(path: string, init?: NextFetchInit, options?: { timeoutMs?: number; retries?: number }) {
+  const { timeoutMs = 5000, retries = 2 } = options ?? {};
   const baseUrl = resolveBaseUrl();
-  const response = await fetch(`${baseUrl}${path}`, {
-    ...init,
-    headers: {
-      "Content-Type": "application/json",
-      ...init?.headers,
-    },
-    cache: "no-store",
-  });
+  let attempt = 0;
+  let lastError: unknown;
 
-  if (!response.ok) {
-    throw new Error(`Failed to fetch ${path}: ${response.statusText}`);
+  while (attempt <= retries) {
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        const response = await fetch(`${baseUrl}${path}`, {
+          ...init,
+          headers: {
+            "Content-Type": "application/json",
+            ...init?.headers,
+          },
+          cache: init?.cache ?? "force-cache",
+          next: {
+            revalidate: MARKETING_REVALIDATE_SECONDS,
+            ...init?.next,
+          },
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          throw new Error(`Failed to fetch ${path}: ${response.status} ${response.statusText}`);
+        }
+
+        return (await response.json()) as T;
+      } finally {
+        clearTimeout(timeout);
+      }
+    } catch (error) {
+      lastError = error instanceof Error && error.name === "AbortError"
+        ? new Error(`Request to ${path} timed out after ${timeoutMs}ms`)
+        : error;
+
+      if (attempt === retries) {
+        throw lastError instanceof Error ? lastError : new Error(String(lastError));
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 2 ** attempt * 100));
+      attempt += 1;
+    }
   }
 
-  return (await response.json()) as T;
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }
 
-export async function fetchLandingContent() {
-  return fetchFromApi<LandingContent>("/api/landing");
+export async function fetchLandingContent(): Promise<MarketingFetchResult<LandingContent>> {
+  try {
+    const data = await fetchFromApi<LandingContent>("/api/landing");
+    return { data, source: "remote" };
+  } catch (error) {
+    console.error("Failed to fetch landing content from API, using local fallback", error);
+    const fallback = await getLandingContent();
+    return {
+      data: fallback,
+      error: error instanceof Error ? error : new Error(String(error)),
+      source: "fallback",
+    };
+  }
 }
 
-export async function fetchFaqContent() {
-  return fetchFromApi<FAQContent>("/api/faq");
+export async function fetchFaqContent(): Promise<MarketingFetchResult<FAQContent>> {
+  try {
+    const data = await fetchFromApi<FAQContent>("/api/faq");
+    return { data, source: "remote" };
+  } catch (error) {
+    console.error("Failed to fetch FAQ content from API, using local fallback", error);
+    const fallback = await getFaqContent();
+    return {
+      data: fallback,
+      error: error instanceof Error ? error : new Error(String(error)),
+      source: "fallback",
+    };
+  }
 }


### PR DESCRIPTION
## Summary
- add retry, timeout, and caching logic to marketing content fetch helpers with local data fallbacks
- surface fallback notices and skeleton states across the landing, FAQ, and preview pages for graceful degradation
- log failures for observability and enable ISR on marketing pages

## Testing
- npm run lint *(fails: Next.js CLI rejects next.config.ts in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690efd3d61648322a16cc440994ade5e)