### PR TITLE
Use supabase client for access request persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,21 @@ npm run dev
 
 Visit `http://localhost:3000` to explore the voice-first landing experience.
 
+### Supabase configuration (optional but recommended)
+
+The application now auto-detects a Supabase backend for durable storage. To enable it:
+
+1. Create a Supabase project and execute [`docs/supabase/access-requests-table.sql`](docs/supabase/access-requests-table.sql) to provision the `access_requests` table.
+2. Add the following environment variables to your `.env.local` (or hosting provider secrets):
+
+   ```bash
+   SUPABASE_URL="https://your-project-ref.supabase.co"
+   SUPABASE_SERVICE_ROLE_KEY="your-service-role-key" # or set SUPABASE_KEY to use an anon key with permissive RLS
+   SUPABASE_ACCESS_REQUESTS_TABLE="access_requests" # optional override
+   ```
+
+3. Restart the dev server. The `/api/request-access` endpoint will now read/write access requests in Supabase while preserving the JSON-file fallback when credentials are absent.
+
 ## Scripts
 
 - `npm run dev` — start the development server
@@ -36,3 +51,5 @@ src/
 ## Roadmap
 
 This prototype focuses on communicating the system vision. Upcoming work will layer in live voice capture, script editing surfaces, reference asset management, and backend orchestration described in the blueprint.
+
+See [`docs/gap-remediation-plan.md`](docs/gap-remediation-plan.md) for the detailed remediation plan and sequencing.

--- a/docs/gap-remediation-plan.md
+++ b/docs/gap-remediation-plan.md
@@ -1,0 +1,101 @@
+# Gap Remediation Plan
+
+This plan breaks down the major gaps identified in the Script-Speech prototype and outlines the concrete steps required to close them. Each section lists near-term backlog items, longer-term projects, and dependencies to help sequence work.
+
+## 1. Voice-first onboarding & adaptive drafting
+- **Goal:** Replace static marketing copy with an interactive onboarding flow that captures creator intent via voice/text and seeds a persistent ScriptDoc.
+- **Near-term tasks:**
+  - Implement project session state (project creation, ScriptDoc persistence) backed by Supabase.
+  - Scaffold a multi-step onboarding wizard UI (outline intents, tonal preferences, deliverable goals).
+  - Add voice capture pipeline that stores transcripts and metadata.
+- **Longer-term initiatives:**
+  - Introduce iterative outline → beat → scene agent orchestration.
+  - Enable bidirectional editing (voice commands updating text, text edits re-driving voice responses).
+- **Dependencies:** Supabase project schema, realtime orchestration services, moderation tooling.
+
+## 2. Functional completeness & project lifecycle
+- **Goal:** Provide end-to-end project management, autosave, export delivery, and collaboration primitives.
+- **Near-term tasks:**
+  - Persist projects, script docs, and export jobs in Supabase tables.
+  - Replace in-memory export queue with Supabase-backed job table + status polling API.
+  - Add authenticated download endpoints with signed URLs.
+- **Longer-term initiatives:**
+  - Version history and branching for ScriptDoc revisions.
+  - Email notifications and calendar integrations for approvals.
+- **Dependencies:** Supabase storage, email delivery provider, background worker infrastructure.
+
+## 3. Data architecture & storage hardening
+- **Goal:** Move off in-process storage to managed services with durability, access control, and observability.
+- **Near-term tasks:**
+  - Configure Supabase as the primary database (see Section 8 for schema starting point).
+  - Wire asset uploads to durable object storage (Supabase Storage or S3) with signed upload URLs.
+  - Add audit logging for critical mutations.
+- **Longer-term initiatives:**
+  - Introduce Redis/Upstash for caching and rate limiting.
+  - Implement data retention, encryption at rest, and privacy workflows.
+- **Dependencies:** Infrastructure provisioning, secret management strategy.
+
+## 4. AI orchestration & toolchain
+- **Goal:** Deliver planner, beat, and scene agents that collaborate on story development and respond to reference material.
+- **Near-term tasks:**
+  - Define canonical prompt/response schemas and JSON schema validation utilities.
+  - Implement orchestration service that coordinates agent calls against OpenAI Realtime / Responses APIs.
+  - Integrate reference-aware retrieval (embedding + similarity search) backed by Supabase pgvector.
+- **Longer-term initiatives:**
+  - Add evaluation harnesses and guardrails for tone, safety, and brand alignment.
+  - Build adaptive agent selection based on project genre and stage.
+- **Dependencies:** Access to OpenAI APIs, vector storage, evaluation dataset.
+
+## 5. Reference asset lifecycle
+- **Goal:** Support production-ready asset ingestion, scanning, and tagging through the studio.
+- **Near-term tasks:**
+  - Persist asset metadata in Supabase with storage bucket references.
+  - Integrate antivirus/transcoding webhooks (e.g., Helix, Cloudflare) and update status UI accordingly.
+  - Expose tagging endpoints that associate assets with beats/scenes in the ScriptDoc.
+- **Longer-term initiatives:**
+  - Automated derivative generation (waveforms, thumbnails, captions).
+  - CDN-backed delivery with signed URLs and usage analytics.
+- **Dependencies:** Media processing pipeline, storage provider, background queue.
+
+## 6. Security, privacy, and compliance
+- **Goal:** Introduce authentication, access controls, and policy enforcement that align with studio requirements.
+- **Near-term tasks:**
+  - Enable Supabase Auth (magic link + OAuth) and gate studio routes behind sessions.
+  - Add server-side RBAC checks for project resources.
+  - Expand rate limiting beyond access requests (API tokens, asset uploads).
+- **Longer-term initiatives:**
+  - Data retention policies, audit exports, and admin dashboards.
+  - SOC 2 aligned logging, PII redaction, and consent tracking.
+- **Dependencies:** Auth UX work, policy documentation, logging provider.
+
+## 7. Testing, DevOps, and observability
+- **Goal:** Establish confidence in deployments through automated testing, linting, and runtime telemetry.
+- **Near-term tasks:**
+  - Add unit tests for API routes and libraries (Jest + React Testing Library).
+  - Configure GitHub Actions CI for linting, type-checking, and tests.
+  - Instrument key flows with OpenTelemetry traces/metrics.
+- **Longer-term initiatives:**
+  - Add integration tests that spin up Supabase test containers.
+  - Implement canary deploys and release automation.
+- **Dependencies:** Testing framework setup, observability vendor.
+
+## 8. Cross-platform experience
+- **Goal:** Extend the Script-Speech experience beyond web to mobile and offline contexts.
+- **Near-term tasks:**
+  - Share core ScriptDoc models and API clients with an Expo app scaffold.
+  - Evaluate offline caching for script editing using SQLite/WatermelonDB.
+- **Longer-term initiatives:**
+  - Feature flag service coordinating progressive rollout across platforms.
+  - Native integrations (call sheets, casting tools) aligned with studio workflows.
+- **Dependencies:** Monorepo tooling, cross-platform design system.
+
+## Supabase backend decision
+Setting up Supabase is the recommended next step to unblock durable storage and auth workstreams. This repository will treat Supabase as the default database, while retaining file-based fallbacks for local development. The `access_requests` table schema is provided in `docs/supabase/access-requests-table.sql` and the application auto-detects Supabase configuration via the `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` environment variables.
+
+## Immediate next actions
+1. Land Supabase-backed access request persistence (implemented in this change) while keeping the local JSON fallback for contributors without Supabase credentials.
+2. Create foundational Supabase tables for projects, script docs, assets, and export jobs.
+3. Migrate API routes to use the new persistence layer iteratively, starting with access requests.
+4. Introduce Supabase Auth and server-side session helpers to secure the studio preview.
+
+This roadmap will evolve as Supabase integration matures and as higher-priority deliverables emerge from user testing.

--- a/docs/supabase/access-requests-table.sql
+++ b/docs/supabase/access-requests-table.sql
@@ -1,0 +1,29 @@
+-- Access request persistence for Script-Speech
+-- Run this SQL in your Supabase project to provision the backing table.
+
+create table if not exists public.access_requests (
+  id uuid primary key,
+  email text not null,
+  message text,
+  metadata jsonb,
+  client jsonb,
+  submitted_at timestamptz not null default timezone('utc', now())
+);
+
+-- Indexes to support rate limiting and listing.
+create index if not exists access_requests_email_submitted_at_idx
+  on public.access_requests (email, submitted_at desc);
+
+-- RLS policies can be tightened later; for now restrict to service role usage only.
+alter table public.access_requests enable row level security;
+
+-- Allow the service role to perform full CRUD (API uses service role key).
+create policy "Service role full access" on public.access_requests
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+drop policy if exists "Public insert access requests" on public.access_requests;
+create policy "Public insert access requests" on public.access_requests
+  for insert
+  with check (auth.role() in ('anon', 'authenticated', 'service_role'));

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@supabase/supabase-js": "2.45.3",
     "next": "14.2.11",
     "react": "18.3.1",
     "react-dom": "18.3.1"

--- a/src/lib/accessRequests.server.ts
+++ b/src/lib/accessRequests.server.ts
@@ -2,6 +2,14 @@ import { randomUUID } from "node:crypto";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+const SUPABASE_URL = process.env.SUPABASE_URL?.trim();
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY?.trim();
+const SUPABASE_GENERIC_KEY = process.env.SUPABASE_KEY?.trim();
+const SUPABASE_ACCESS_REQUESTS_TABLE =
+  process.env.SUPABASE_ACCESS_REQUESTS_TABLE?.trim() ?? "access_requests";
+
 type NullableString = string | null | undefined;
 
 export type AccessRequestMetadata = {
@@ -48,6 +56,12 @@ const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/i;
 const STORE_PATH =
   process.env.ACCESS_REQUEST_STORE_PATH ??
   path.join(process.cwd(), ".data", "access-requests.json");
+
+type AccessRequestPersistence = {
+  create(record: AccessRequestRecord): Promise<void>;
+  list(): Promise<AccessRequestRecord[]>;
+  hasRecentSubmission(email: string, windowStart: Date): Promise<boolean>;
+};
 
 function getRateLimitMinutes(): number {
   const value = Number(process.env.ACCESS_REQUEST_RATE_LIMIT_MINUTES);
@@ -140,6 +154,144 @@ function sanitizeClientContext(
   return Object.keys(normalized).length > 0 ? normalized : undefined;
 }
 
+const filePersistence: AccessRequestPersistence = {
+  async create(record) {
+    const existing = await readStore();
+    await writeStore([...existing, record]);
+  },
+  async list() {
+    const records = await readStore();
+    return records.sort(
+      (a, b) => new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime(),
+    );
+  },
+  async hasRecentSubmission(email, windowStart) {
+    const existingRequests = await readStore();
+    return existingRequests.some((request) => {
+      if (request.email !== email) {
+        return false;
+      }
+
+      const submittedAt = new Date(request.submittedAt);
+      return submittedAt > windowStart;
+    });
+  },
+};
+
+type SupabaseAccessRequestRow = {
+  id: string;
+  email: string;
+  message: string | null;
+  metadata: AccessRequestMetadata | null;
+  client: AccessRequestClientContext | null;
+  submitted_at: string;
+};
+
+let cachedSupabaseClient: SupabaseClient | null = null;
+
+function resolveSupabaseKey(): string | undefined {
+  return SUPABASE_SERVICE_ROLE_KEY || SUPABASE_GENERIC_KEY;
+}
+
+function getSupabaseClient(): SupabaseClient | null {
+  const key = resolveSupabaseKey();
+  if (!SUPABASE_URL || !key) {
+    return null;
+  }
+
+  if (!cachedSupabaseClient) {
+    cachedSupabaseClient = createClient(SUPABASE_URL, key, {
+      auth: {
+        persistSession: false,
+      },
+    });
+  }
+
+  return cachedSupabaseClient;
+}
+
+function assertSupabaseConfigured(): SupabaseClient {
+  const client = getSupabaseClient();
+  if (!client) {
+    throw new AccessRequestError("Supabase is not configured.", 500);
+  }
+  return client;
+}
+
+const supabasePersistence: AccessRequestPersistence = {
+  async create(record) {
+    const client = assertSupabaseConfigured();
+    const { error } = await client.from(SUPABASE_ACCESS_REQUESTS_TABLE).insert({
+      id: record.id,
+      email: record.email,
+      message: record.message ?? null,
+      metadata: record.metadata ?? null,
+      client: record.client ?? null,
+      submitted_at: record.submittedAt,
+    });
+
+    if (error) {
+      throw new AccessRequestError(
+        error.message ?? "Failed to persist access request to Supabase.",
+        error.status ?? 500,
+      );
+    }
+  },
+  async list() {
+    const client = assertSupabaseConfigured();
+    const { data, error } = await client
+      .from(SUPABASE_ACCESS_REQUESTS_TABLE)
+      .select("*")
+      .order("submitted_at", { ascending: false });
+
+    if (error) {
+      throw new AccessRequestError(
+        error.message ?? "Failed to list access requests from Supabase.",
+        error.status ?? 500,
+      );
+    }
+
+    return (data ?? []).map(transformSupabaseRow);
+  },
+  async hasRecentSubmission(email, windowStart) {
+    const client = assertSupabaseConfigured();
+    const { data, error } = await client
+      .from(SUPABASE_ACCESS_REQUESTS_TABLE)
+      .select("id")
+      .eq("email", email)
+      .gte("submitted_at", windowStart.toISOString())
+      .limit(1);
+
+    if (error) {
+      throw new AccessRequestError(
+        error.message ?? "Failed to query access requests from Supabase.",
+        error.status ?? 500,
+      );
+    }
+
+    return Array.isArray(data) && data.length > 0;
+  },
+};
+
+function transformSupabaseRow(row: SupabaseAccessRequestRow): AccessRequestRecord {
+  return {
+    id: row.id,
+    email: row.email,
+    message: row.message ?? undefined,
+    metadata: row.metadata ?? undefined,
+    client: row.client ?? undefined,
+    submittedAt: row.submitted_at,
+  };
+}
+
+function getPersistence(): AccessRequestPersistence {
+  if (SUPABASE_URL && resolveSupabaseKey()) {
+    return supabasePersistence;
+  }
+
+  return filePersistence;
+}
+
 export async function createAccessRequest({
   email,
   message,
@@ -151,19 +303,16 @@ export async function createAccessRequest({
   const normalizedMetadata = sanitizeMetadata(metadata);
   const normalizedClient = sanitizeClientContext(client);
 
-  const existingRequests = await readStore();
   const now = new Date();
   const rateLimitMinutes = getRateLimitMinutes();
   const windowStart = new Date(now.getTime() - rateLimitMinutes * 60 * 1000);
 
-  const hasRecentSubmission = existingRequests.some((request) => {
-    if (request.email !== normalizedEmail) {
-      return false;
-    }
+  const persistence = getPersistence();
 
-    const submittedAt = new Date(request.submittedAt);
-    return submittedAt > windowStart;
-  });
+  const hasRecentSubmission = await persistence.hasRecentSubmission(
+    normalizedEmail,
+    windowStart,
+  );
 
   if (hasRecentSubmission) {
     throw new AccessRequestError(
@@ -181,12 +330,12 @@ export async function createAccessRequest({
     submittedAt: now.toISOString(),
   };
 
-  await writeStore([...existingRequests, record]);
+  await persistence.create(record);
 
   return record;
 }
 
 export async function listAccessRequests(): Promise<AccessRequestRecord[]> {
-  const records = await readStore();
-  return records.sort((a, b) => new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime());
+  const persistence = getPersistence();
+  return persistence.list();
 }


### PR DESCRIPTION
## Summary
- switch the access request service to use the official supabase-js client and support either service-role or anon keys
- document the SUPABASE_KEY option and add an optional RLS policy for anon inserts in the Supabase schema guide
- add the supabase-js dependency required for the server integration

## Testing
- npm run lint *(fails: Next.js CLI rejects next.config.ts when running lint in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690efc4d25148322bd4501d0517a88c5)