### PR TITLE
Add cloud storage providers with signed upload validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "3.665.0",
+    "@aws-sdk/s3-request-presigner": "3.665.0",
     "@supabase/supabase-js": "2.45.3",
     "next": "14.2.11",
     "react": "18.3.1",

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,3 +1,27 @@
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+
+import { getSupabaseClient } from "@/lib/db/client";
+import { SUPABASE_URL, isSupabaseConfigured } from "@/lib/db/config";
+
+import {
+  S3_ACCESS_KEY_ID,
+  S3_BUCKET,
+  S3_ENDPOINT,
+  S3_FORCE_PATH_STYLE,
+  S3_PREFIX,
+  S3_PUBLIC_BASE_URL,
+  S3_REGION,
+  S3_SECRET_ACCESS_KEY,
+  S3_SESSION_TOKEN,
+  STORAGE_ALLOWED_CONTENT_TYPES,
+  STORAGE_MAX_UPLOAD_BYTES,
+  STORAGE_SIGNED_URL_TTL_SECONDS,
+  SUPABASE_STORAGE_BUCKET,
+  SUPABASE_STORAGE_FOLDER,
+  getStorageDriver,
+} from "./storage/config";
+
 export interface SignedUpload {
   uploadUrl: string;
   method: "PUT" | "POST";
@@ -15,23 +39,259 @@ export interface StorageProvider {
   }): Promise<SignedUpload>;
 }
 
+function normaliseContentType(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function isContentTypeAllowed(contentType: string): boolean {
+  const normalised = normaliseContentType(contentType);
+  return STORAGE_ALLOWED_CONTENT_TYPES.some((pattern) => {
+    const p = pattern.toLowerCase();
+    if (!p) return false;
+    if (p === "*") return true;
+    if (p.includes("*")) {
+      const escaped = p
+        .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+        .replace(/\\\*/g, ".*");
+      return new RegExp(`^${escaped}$`).test(normalised);
+    }
+    if (p.endsWith("/")) {
+      return normalised.startsWith(p);
+    }
+    if (p.endsWith("/*")) {
+      return normalised.startsWith(p.slice(0, -1));
+    }
+    return normalised === p;
+  });
+}
+
+function ensureUploadAllowed({
+  contentType,
+  size,
+}: {
+  contentType: string;
+  size: number;
+}) {
+  if (!Number.isFinite(size) || size <= 0) {
+    throw new Error("Upload size must be greater than zero");
+  }
+
+  if (size > STORAGE_MAX_UPLOAD_BYTES) {
+    throw new Error("Upload exceeds configured size limit");
+  }
+
+  if (!contentType) {
+    throw new Error("Content type is required");
+  }
+
+  if (!isContentTypeAllowed(contentType)) {
+    throw new Error(`Uploads with content type '${contentType}' are not permitted`);
+  }
+}
+
+const CONTENT_TYPE_EXTENSION_MAP: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  "image/svg+xml": "svg",
+  "image/heic": "heic",
+  "image/heif": "heif",
+  "audio/mpeg": "mp3",
+  "audio/wav": "wav",
+  "audio/x-wav": "wav",
+  "audio/aac": "aac",
+  "audio/ogg": "ogg",
+  "audio/flac": "flac",
+  "video/mp4": "mp4",
+  "video/quicktime": "mov",
+  "video/webm": "webm",
+  "application/pdf": "pdf",
+  "application/json": "json",
+  "text/plain": "txt",
+};
+
+function getExtensionForContentType(contentType: string): string {
+  const normalised = normaliseContentType(contentType);
+  if (CONTENT_TYPE_EXTENSION_MAP[normalised]) {
+    return CONTENT_TYPE_EXTENSION_MAP[normalised];
+  }
+  const subtype = normalised.split("/")[1];
+  return subtype ? subtype.replace(/[^a-z0-9]+/gi, "-").toLowerCase() : "bin";
+}
+
+function buildStoragePath({
+  assetId,
+  projectId,
+  contentType,
+  prefix,
+}: {
+  assetId: string;
+  projectId?: string | null;
+  contentType: string;
+  prefix: string;
+}) {
+  const extension = getExtensionForContentType(contentType);
+  const safeProjectSegment = projectId?.replace(/[^a-z0-9-]+/gi, "-").toLowerCase() ?? "shared";
+  return `${prefix}/${safeProjectSegment}/${assetId}.${extension}`;
+}
+
 class LocalStorageProvider implements StorageProvider {
-  async createSignedUpload({ assetId, contentType }: {
+  async createSignedUpload({
+    assetId,
+    contentType,
+    size,
+  }: {
     assetId: string;
     contentType: string;
     size: number;
     projectId?: string | null;
   }): Promise<SignedUpload> {
-    const expires = new Date(Date.now() + 5 * 60 * 1000);
+    ensureUploadAllowed({ contentType, size });
+    const expires = new Date(Date.now() + STORAGE_SIGNED_URL_TTL_SECONDS * 1000);
 
     return {
       uploadUrl: `/api/assets?assetId=${assetId}`,
       method: "PUT",
       headers: {
-        "Content-Type": contentType
+        "Content-Type": contentType,
       },
       assetUrl: `/api/assets/${assetId}`,
-      expiresAt: expires.toISOString()
+      expiresAt: expires.toISOString(),
+    };
+  }
+}
+
+class SupabaseStorageProvider implements StorageProvider {
+  async createSignedUpload({
+    assetId,
+    contentType,
+    size,
+    projectId,
+  }: {
+    assetId: string;
+    contentType: string;
+    size: number;
+    projectId?: string | null;
+  }): Promise<SignedUpload> {
+    if (!isSupabaseConfigured()) {
+      throw new Error("Supabase storage is not configured");
+    }
+
+    ensureUploadAllowed({ contentType, size });
+
+    const client = getSupabaseClient();
+    const path = buildStoragePath({
+      assetId,
+      contentType,
+      projectId,
+      prefix: SUPABASE_STORAGE_FOLDER,
+    });
+
+    const { data, error } = await client.storage
+      .from(SUPABASE_STORAGE_BUCKET)
+      .createSignedUploadUrl(path, STORAGE_SIGNED_URL_TTL_SECONDS);
+
+    if (error || !data) {
+      console.error("Failed to create Supabase signed upload", error);
+      throw error ?? new Error("Unable to create signed upload");
+    }
+
+    const baseUrl = client.storage.from(SUPABASE_STORAGE_BUCKET).getPublicUrl(path).data.publicUrl;
+    const supabaseBaseUrl = SUPABASE_URL?.replace(/\/$/, "");
+    const absoluteUploadUrl = data.signedUrl.startsWith("http")
+      ? data.signedUrl
+      : `${supabaseBaseUrl ?? ""}${data.signedUrl.startsWith("/") ? "" : "/"}${data.signedUrl}`;
+    const expiresAt = new Date(Date.now() + STORAGE_SIGNED_URL_TTL_SECONDS * 1000).toISOString();
+
+    const fallbackAssetUrl = supabaseBaseUrl
+      ? `${supabaseBaseUrl}/storage/v1/object/public/${SUPABASE_STORAGE_BUCKET}/${path}`
+      : `${SUPABASE_STORAGE_BUCKET}/${path}`;
+
+    return {
+      uploadUrl: absoluteUploadUrl,
+      method: "PUT",
+      headers: {
+        "Content-Type": contentType,
+        "x-upsert": "false",
+      },
+      assetUrl: baseUrl ?? fallbackAssetUrl,
+      expiresAt,
+    };
+  }
+}
+
+class S3StorageProvider implements StorageProvider {
+  private client: S3Client;
+
+  constructor() {
+    if (!S3_BUCKET || !S3_REGION) {
+      throw new Error("S3 storage is not configured");
+    }
+
+    this.client = new S3Client({
+      region: S3_REGION,
+      endpoint: S3_ENDPOINT,
+      forcePathStyle: S3_FORCE_PATH_STYLE,
+      credentials:
+        S3_ACCESS_KEY_ID && S3_SECRET_ACCESS_KEY
+          ? {
+              accessKeyId: S3_ACCESS_KEY_ID,
+              secretAccessKey: S3_SECRET_ACCESS_KEY!,
+              sessionToken: S3_SESSION_TOKEN,
+            }
+          : undefined,
+    });
+  }
+
+  async createSignedUpload({
+    assetId,
+    contentType,
+    size,
+    projectId,
+  }: {
+    assetId: string;
+    contentType: string;
+    size: number;
+    projectId?: string | null;
+  }): Promise<SignedUpload> {
+    if (!S3_BUCKET || !S3_REGION) {
+      throw new Error("S3 storage is not configured");
+    }
+
+    ensureUploadAllowed({ contentType, size });
+
+    const key = buildStoragePath({
+      assetId,
+      contentType,
+      projectId,
+      prefix: S3_PREFIX,
+    });
+
+    const command = new PutObjectCommand({
+      Bucket: S3_BUCKET,
+      Key: key,
+      ContentType: contentType,
+      ContentLength: size,
+    });
+
+    const signedUrl = await getSignedUrl(this.client, command, {
+      expiresIn: STORAGE_SIGNED_URL_TTL_SECONDS,
+    });
+
+    const expiresAt = new Date(Date.now() + STORAGE_SIGNED_URL_TTL_SECONDS * 1000).toISOString();
+    const assetUrl = S3_PUBLIC_BASE_URL
+      ? `${S3_PUBLIC_BASE_URL.replace(/\/$/, "")}/${key}`
+      : `https://${S3_BUCKET}.s3.${S3_REGION}.amazonaws.com/${key}`;
+
+    return {
+      uploadUrl: signedUrl,
+      method: "PUT",
+      headers: {
+        "Content-Type": contentType,
+      },
+      assetUrl,
+      expiresAt,
     };
   }
 }
@@ -40,7 +300,14 @@ let provider: StorageProvider | null = null;
 
 export function getStorageProvider(): StorageProvider {
   if (!provider) {
-    provider = new LocalStorageProvider();
+    const driver = getStorageDriver();
+    if (driver === "supabase") {
+      provider = new SupabaseStorageProvider();
+    } else if (driver === "s3") {
+      provider = new S3StorageProvider();
+    } else {
+      provider = new LocalStorageProvider();
+    }
   }
 
   return provider;

--- a/src/lib/storage/config.ts
+++ b/src/lib/storage/config.ts
@@ -1,0 +1,67 @@
+const STORAGE_DRIVER = process.env.STORAGE_DRIVER?.trim() ?? process.env.ASSET_STORAGE_DRIVER?.trim();
+
+export type StorageDriver = "supabase" | "s3" | "local";
+
+export function getStorageDriver(): StorageDriver {
+  if (STORAGE_DRIVER === "supabase" || STORAGE_DRIVER === "s3") {
+    return STORAGE_DRIVER;
+  }
+  if (process.env.SUPABASE_STORAGE_BUCKET && process.env.SUPABASE_URL) {
+    return "supabase";
+  }
+  if (process.env.S3_BUCKET && process.env.AWS_REGION) {
+    return "s3";
+  }
+  return "local";
+}
+
+export const SUPABASE_STORAGE_BUCKET = process.env.SUPABASE_STORAGE_BUCKET?.trim() || "reference-assets";
+export const SUPABASE_STORAGE_FOLDER = process.env.SUPABASE_STORAGE_FOLDER?.trim() || "reference";
+
+export const STORAGE_SIGNED_URL_TTL_SECONDS = (() => {
+  const raw = process.env.STORAGE_SIGNED_URL_TTL_SECONDS ?? process.env.ASSET_SIGNED_URL_TTL;
+  const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 5 * 60;
+})();
+
+export const STORAGE_MAX_UPLOAD_BYTES = (() => {
+  const raw = process.env.STORAGE_MAX_UPLOAD_BYTES ?? process.env.ASSET_MAX_UPLOAD_BYTES;
+  if (!raw) {
+    return 500 * 1024 * 1024; // 500 MB default
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 500 * 1024 * 1024;
+})();
+
+export const STORAGE_ALLOWED_CONTENT_TYPES = (() => {
+  const raw = process.env.STORAGE_ALLOWED_CONTENT_TYPES ?? process.env.ASSET_ALLOWED_CONTENT_TYPES;
+  if (!raw) {
+    return [
+      "image/",
+      "audio/",
+      "video/",
+      "application/pdf",
+      "application/json",
+      "text/plain",
+    ];
+  }
+  return raw
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+})();
+
+export const S3_BUCKET = process.env.S3_BUCKET?.trim() ?? process.env.ASSET_S3_BUCKET?.trim();
+export const S3_PREFIX = process.env.S3_PREFIX?.trim() ?? process.env.ASSET_S3_PREFIX?.trim() ?? "assets";
+export const S3_REGION = process.env.S3_REGION?.trim() ?? process.env.AWS_REGION?.trim();
+export const S3_ENDPOINT = process.env.S3_ENDPOINT?.trim();
+export const S3_FORCE_PATH_STYLE = (() => {
+  const raw = process.env.S3_FORCE_PATH_STYLE ?? process.env.ASSET_S3_FORCE_PATH_STYLE;
+  if (!raw) return false;
+  return ["1", "true", "on", "yes"].includes(raw.toLowerCase());
+})();
+export const S3_PUBLIC_BASE_URL = process.env.S3_PUBLIC_BASE_URL?.trim();
+
+export const S3_ACCESS_KEY_ID = process.env.S3_ACCESS_KEY_ID?.trim() ?? process.env.AWS_ACCESS_KEY_ID?.trim();
+export const S3_SECRET_ACCESS_KEY = process.env.S3_SECRET_ACCESS_KEY?.trim() ?? process.env.AWS_SECRET_ACCESS_KEY?.trim();
+export const S3_SESSION_TOKEN = process.env.S3_SESSION_TOKEN?.trim() ?? process.env.AWS_SESSION_TOKEN?.trim();


### PR DESCRIPTION
## Summary
- add configurable storage driver selection for Supabase, S3, or local uploads
- validate upload size and content-types before generating signed URLs
- integrate Supabase Storage and Amazon S3 presigned upload generation with env-based configuration

## Testing
- not run (registry access to install new sdk packages is blocked in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691415193f88832285c6670cb48f697c)