### PR TITLE
Add Supabase-backed marketing content retrieval

### DIFF
--- a/src/lib/siteData.ts
+++ b/src/lib/siteData.ts
@@ -3,20 +3,69 @@ import { coreFeatures } from "@/data/coreFeatures";
 import { platformPillars } from "@/data/platformPillars";
 import { workflowStages } from "@/data/workflowStages";
 
+import { getSupabaseServiceClient } from "@/lib/supabase.server";
+
 export type FAQContent = {
   coreFeatures: typeof coreFeatures;
   workflowStages: typeof workflowStages;
   platformPillars: typeof platformPillars;
 };
 
+const MARKETING_CONTENT_TABLE =
+  process.env.SUPABASE_MARKETING_CONTENT_TABLE ?? "marketing_content";
+
+type MarketingContentRow<T> = {
+  slug: string;
+  content: T;
+  updated_at: string | null;
+};
+
+async function fetchMarketingContent<T>(slug: string, fallback: T): Promise<T> {
+  const supabase = getSupabaseServiceClient();
+
+  if (!supabase) {
+    return structuredClone(fallback);
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from<MarketingContentRow<T>>(MARKETING_CONTENT_TABLE)
+      .select("content")
+      .eq("slug", slug)
+      .maybeSingle();
+
+    if (error) {
+      console.error(`Failed to fetch marketing content for slug "${slug}":`, error);
+      return structuredClone(fallback);
+    }
+
+    if (!data?.content) {
+      return structuredClone(fallback);
+    }
+
+    try {
+      return structuredClone(data.content);
+    } catch (cloneError) {
+      console.error(
+        `Failed to clone marketing content for slug "${slug}", using fallback instead`,
+        cloneError,
+      );
+      return structuredClone(fallback);
+    }
+  } catch (error) {
+    console.error(`Unexpected error retrieving marketing content for slug "${slug}":`, error);
+    return structuredClone(fallback);
+  }
+}
+
 export async function getLandingContent(): Promise<LandingContent> {
-  return structuredClone(landingContent);
+  return fetchMarketingContent<LandingContent>("landing", landingContent);
 }
 
 export async function getFaqContent(): Promise<FAQContent> {
-  return {
-    coreFeatures: structuredClone(coreFeatures),
-    workflowStages: structuredClone(workflowStages),
-    platformPillars: structuredClone(platformPillars),
-  };
+  return fetchMarketingContent<FAQContent>("faq", {
+    coreFeatures,
+    workflowStages,
+    platformPillars,
+  });
 }


### PR DESCRIPTION
## Summary
- add a Supabase-backed fallback loader for landing and FAQ marketing content
- default to local structured clones when Supabase is unavailable or returns invalid data
- allow the marketing content table name to be configured with SUPABASE_MARKETING_CONTENT_TABLE

## Testing
- npm test *(fails: ReferenceError: React is not defined in src/components/AnimatedHeadline.test.tsx)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69141618c0088322bb4d80286430422e)