### PR TITLE
Load marketing copy from Supabase when available

### DIFF
--- a/docs/supabase/marketing-content-table.sql
+++ b/docs/supabase/marketing-content-table.sql
@@ -1,0 +1,24 @@
+-- Marketing content storage
+-- Provides editable JSON blobs for landing and FAQ copy surfaced on the marketing site.
+
+create table if not exists public.marketing_content (
+  slug text primary key,
+  data jsonb not null,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create or replace function public.update_marketing_content_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = timezone('utc', now());
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger marketing_content_set_updated_at
+before update on public.marketing_content
+for each row execute function public.update_marketing_content_updated_at();
+
+comment on table public.marketing_content is 'Stores editable marketing JSON payloads keyed by slug (e.g. landing, faq).';
+comment on column public.marketing_content.data is 'Marketing content payload rendered on the marketing site.';

--- a/src/lib/db/marketingContent.ts
+++ b/src/lib/db/marketingContent.ts
@@ -1,0 +1,38 @@
+import type { PostgrestError } from "@supabase/supabase-js";
+
+import { getSupabaseServiceClient } from "@/lib/supabase.server";
+
+import type { MarketingContentRow } from "./schema";
+
+export type MarketingContentSlug = "landing" | "faq";
+
+function shouldLogError(error: PostgrestError | null): error is PostgrestError {
+  if (!error) {
+    return false;
+  }
+
+  // PGRST116 indicates no rows returned for maybeSingle, which is expected
+  // when the marketing content has not yet been created.
+  return error.code !== "PGRST116";
+}
+
+export async function loadMarketingContent<T>(
+  slug: MarketingContentSlug,
+): Promise<T | null> {
+  const supabase = getSupabaseServiceClient();
+  if (!supabase) {
+    return null;
+  }
+
+  const { data, error } = await supabase
+    .from<MarketingContentRow<T>>("marketing_content")
+    .select("data")
+    .eq("slug", slug)
+    .maybeSingle();
+
+  if (shouldLogError(error)) {
+    console.error(`Failed to load marketing content for slug "${slug}"`, error);
+  }
+
+  return data?.data ?? null;
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -73,3 +73,10 @@ export interface ExportJobRow {
   created_at: string;
   updated_at: string;
 }
+
+export interface MarketingContentRow<T = unknown> {
+  slug: string;
+  data: T;
+  created_at: string;
+  updated_at: string;
+}

--- a/src/lib/siteData.ts
+++ b/src/lib/siteData.ts
@@ -3,6 +3,8 @@ import { coreFeatures } from "@/data/coreFeatures";
 import { platformPillars } from "@/data/platformPillars";
 import { workflowStages } from "@/data/workflowStages";
 
+import { loadMarketingContent } from "./db/marketingContent";
+
 export type FAQContent = {
   coreFeatures: typeof coreFeatures;
   workflowStages: typeof workflowStages;
@@ -10,10 +12,20 @@ export type FAQContent = {
 };
 
 export async function getLandingContent(): Promise<LandingContent> {
+  const remoteContent = await loadMarketingContent<LandingContent>("landing");
+  if (remoteContent) {
+    return structuredClone(remoteContent);
+  }
+
   return structuredClone(landingContent);
 }
 
 export async function getFaqContent(): Promise<FAQContent> {
+  const remoteContent = await loadMarketingContent<FAQContent>("faq");
+  if (remoteContent) {
+    return structuredClone(remoteContent);
+  }
+
   return {
     coreFeatures: structuredClone(coreFeatures),
     workflowStages: structuredClone(workflowStages),


### PR DESCRIPTION
## Summary
- add a Supabase-backed loader for marketing content with graceful fallbacks
- update site data helpers to pull landing and FAQ copy from the new source
- document the marketing_content table schema for Supabase provisioning

## Testing
- pnpm lint *(fails: Next.js CLI rejects next.config.ts in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69141618c0088322bb4d80286430422e)