### PR TITLE
fix: require ack token when fetching transcripts

### DIFF
--- a/src/app/api/realtime/orchestrator/route.ts
+++ b/src/app/api/realtime/orchestrator/route.ts
@@ -384,8 +384,14 @@ async function dispatchToolInvocation(
 
 async function handleTranscriptFetch(payload: Record<string, unknown>) {
   const sessionId = typeof payload.sessionId === "string" ? payload.sessionId : null;
-  if (!sessionId) {
-    return NextResponse.json({ error: "sessionId is required" }, { status: 400 });
+  const ackToken = typeof payload.ackToken === "string" ? payload.ackToken : null;
+  if (!sessionId || !ackToken) {
+    return NextResponse.json({ error: "Invalid transcript request" }, { status: 400 });
+  }
+
+  const entry = await ensureSessionCache(sessionId);
+  if (!entry || entry.ackToken !== ackToken) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   try {


### PR DESCRIPTION
## Summary
- require the acknowledgement token when fetching transcript history
- reject requests that lack a session cache entry or supply the wrong token before returning transcripts

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69142ac4e0e48322b36e3b626c811ad5)