### PR TITLE
Fix realtime authorization caching and error handling

### DIFF
--- a/src/app/api/realtime/orchestrator/route.ts
+++ b/src/app/api/realtime/orchestrator/route.ts
@@ -477,15 +477,15 @@ export async function POST(request: NextRequest) {
     }
 
     if (action === "transcript.append") {
-      return handleTranscriptAppend(data, user.id);
+      return await handleTranscriptAppend(data, user.id);
     }
 
     if (action === "transcript.fetch") {
-      return handleTranscriptFetch(data, user.id);
+      return await handleTranscriptFetch(data, user.id);
     }
 
     if (action === "tool.invoke") {
-      return dispatchToolInvocation(data, user.id);
+      return await dispatchToolInvocation(data, user.id);
     }
 
     if (action === "ack.parse") {

--- a/src/lib/authz/projects.server.ts
+++ b/src/lib/authz/projects.server.ts
@@ -1,5 +1,3 @@
-import { cache } from "react";
-
 import { getSupabaseClient } from "@/lib/db/client";
 import { isSupabaseConfigured } from "@/lib/db/config";
 import type { ProjectMemberRow, ProjectRow } from "@/lib/db/schema";
@@ -76,22 +74,23 @@ async function fetchSupabaseMembership(
   return { projectId, userId, role };
 }
 
-const getCachedMembership = cache(
-  async (projectId: string, userId: string): Promise<ProjectMembership | null> => {
-    if (!isSupabaseConfigured()) {
-      return getMockProjectMembership(projectId, userId);
-    }
+async function getProjectMembership(
+  projectId: string,
+  userId: string,
+): Promise<ProjectMembership | null> {
+  if (!isSupabaseConfigured()) {
+    return getMockProjectMembership(projectId, userId);
+  }
 
-    return fetchSupabaseMembership(projectId, userId);
-  },
-);
+  return fetchSupabaseMembership(projectId, userId);
+}
 
 export async function ensureProjectMembership(
   projectId: string,
   userId: string,
   options: { minimumRole?: ProjectRole } = {},
 ): Promise<ProjectMembership> {
-  const membership = await getCachedMembership(projectId, userId);
+  const membership = await getProjectMembership(projectId, userId);
 
   if (!membership) {
     throw new ProjectAuthorizationError();


### PR DESCRIPTION
## Summary
- remove the React cache layer around `ensureProjectMembership` so membership revocations are reflected immediately
- await realtime transcript and tool handlers so authorization errors are caught and converted into 403 responses

## Testing
- npm run test *(fails: ReferenceError: React is not defined in src/components/AnimatedHeadline.test.tsx)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69142ababf44832287685c8673e157d7)