### PR TITLE
Integrate Supabase script doc persistence and autosave endpoints

### DIFF
--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -6,7 +6,10 @@ import {
   updateProject,
   type UpdateProjectInput,
 } from "@/lib/db/projects";
-import { fetchLatestScriptDoc, upsertScriptDoc } from "@/lib/db/scriptDocs";
+import {
+  fetchLatestScriptDoc,
+  upsertScriptDoc,
+} from "@/lib/db/scriptDocs";
 import {
   listEntityAssets,
   listReferenceAssets,
@@ -31,20 +34,22 @@ export async function GET(
     const { user } = await requireServerAuthSession();
     await ensureProjectMembership(projectId, user.id);
 
-    const [project, scriptDoc, references, entityAssets] = await Promise.all([
+    const [project, scriptDocRecord, references, entityAssets] = await Promise.all([
       getProject(projectId),
-      fetchLatestScriptDoc(projectId),
+      fetchLatestScriptDoc(projectId, { preferAutosave: true }),
       listReferenceAssets(projectId),
       listEntityAssets(projectId),
     ]);
 
-    if (!project && !scriptDoc) {
+    if (!project && !scriptDocRecord) {
       return NextResponse.json({ error: "Project not found" }, { status: 404 });
     }
 
     return NextResponse.json({
       project,
-      scriptDoc,
+      scriptDoc: scriptDocRecord?.doc ?? null,
+      scriptDocSource: scriptDocRecord?.recordType ?? null,
+      scriptDocVersion: scriptDocRecord?.versionNumber ?? null,
       assets: {
         references: references.map(serializeReferenceAsset),
         entity: entityAssets.map(serializeEntityAsset),

--- a/src/app/api/projects/[id]/script-doc/autosave/route.ts
+++ b/src/app/api/projects/[id]/script-doc/autosave/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import {
+  createScriptDocAutosave,
+  fetchLatestScriptDoc,
+} from "@/lib/db/scriptDocs";
+import type { ScriptDoc } from "@/lib/scriptDoc";
+import { requireServerAuthSession, UnauthorizedError } from "@/lib/auth/server";
+import {
+  ensureProjectMembership,
+  ProjectAuthorizationError,
+} from "@/lib/authz/projects.server";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  let body: { doc?: ScriptDoc };
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 });
+  }
+
+  if (!body.doc) {
+    return NextResponse.json({ error: "Missing doc" }, { status: 400 });
+  }
+
+  const projectId = params.id;
+
+  try {
+    const { user } = await requireServerAuthSession();
+    await ensureProjectMembership(projectId, user.id, { minimumRole: "member" });
+
+    const record = await createScriptDocAutosave(projectId, body.doc, {
+      sourceVersionId: body.doc.revision?.id ?? null,
+    });
+
+    return NextResponse.json({
+      ok: true,
+      savedAt: record.updatedAt,
+      sourceVersionId: record.sourceVersionId,
+      recordType: record.recordType,
+    });
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (error instanceof ProjectAuthorizationError) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    console.error("Failed to persist autosave", error);
+    return NextResponse.json({ error: "Unable to persist autosave" }, { status: 500 });
+  }
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const projectId = params.id;
+
+  try {
+    const { user } = await requireServerAuthSession();
+    await ensureProjectMembership(projectId, user.id, { minimumRole: "member" });
+
+    const record = await fetchLatestScriptDoc(projectId, { preferAutosave: true });
+
+    if (!record) {
+      return NextResponse.json({ error: "No script doc found" }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      scriptDoc: record.doc,
+      recordType: record.recordType,
+      versionNumber: record.versionNumber,
+      updatedAt: record.updatedAt,
+    });
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (error instanceof ProjectAuthorizationError) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    console.error("Failed to load autosave", error);
+    return NextResponse.json({ error: "Unable to load autosave" }, { status: 500 });
+  }
+}

--- a/src/app/api/projects/[id]/script-doc/versions/route.ts
+++ b/src/app/api/projects/[id]/script-doc/versions/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import {
+  createScriptDocVersion,
+  listScriptDocVersions,
+} from "@/lib/db/scriptDocs";
+import type { ScriptDoc } from "@/lib/scriptDoc";
+import { requireServerAuthSession, UnauthorizedError } from "@/lib/auth/server";
+import {
+  ensureProjectMembership,
+  ProjectAuthorizationError,
+} from "@/lib/authz/projects.server";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const projectId = params.id;
+
+  try {
+    const { user } = await requireServerAuthSession();
+    await ensureProjectMembership(projectId, user.id, { minimumRole: "member" });
+
+    const versions = await listScriptDocVersions(projectId, 20);
+
+    return NextResponse.json({
+      versions: versions.map((record) => ({
+        id: record.id,
+        versionNumber: record.versionNumber,
+        createdAt: record.createdAt,
+        updatedAt: record.updatedAt,
+        doc: record.doc,
+      })),
+    });
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (error instanceof ProjectAuthorizationError) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    console.error("Failed to list versions", error);
+    return NextResponse.json({ error: "Unable to list versions" }, { status: 500 });
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  let body: { doc?: ScriptDoc };
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 });
+  }
+
+  if (!body.doc) {
+    return NextResponse.json({ error: "Missing doc" }, { status: 400 });
+  }
+
+  const projectId = params.id;
+
+  try {
+    const { user } = await requireServerAuthSession();
+    await ensureProjectMembership(projectId, user.id, { minimumRole: "member" });
+
+    const record = await createScriptDocVersion(projectId, body.doc);
+
+    return NextResponse.json({
+      versionNumber: record.versionNumber,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+      id: record.id,
+    });
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (error instanceof ProjectAuthorizationError) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    console.error("Failed to create version", error);
+    return NextResponse.json({ error: "Unable to create version" }, { status: 500 });
+  }
+}

--- a/src/lib/db/assets.ts
+++ b/src/lib/db/assets.ts
@@ -49,7 +49,7 @@ function mapEntityAssetRow(row: EntityAssetRow): EntityAsset {
     entityId: row.entity_id,
     entityType: row.entity_type,
     caption: row.caption,
-    order: row.order,
+    order: row.order_index,
     isPrivate: row.is_private,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -218,7 +218,7 @@ export async function fetchEntityAssets(projectId: string): Promise<EntityAsset[
     .from<EntityAssetRow>("entity_assets")
     .select("*")
     .eq("project_id", projectId)
-    .order("order", { ascending: true });
+    .order("order_index", { ascending: true });
 
   if (error) {
     console.error("Failed to load entity assets", error);
@@ -242,7 +242,7 @@ export async function upsertEntityAssetRecord(
     entity_id: input.entityId,
     entity_type: input.entityType,
     caption: input.caption ?? null,
-    order: input.order ?? 0,
+    order_index: input.order ?? 0,
     is_private: input.isPrivate ?? false,
   } satisfies Partial<EntityAssetRow> & {
     project_id: string;

--- a/src/lib/db/mocks.ts
+++ b/src/lib/db/mocks.ts
@@ -476,6 +476,9 @@ export function getMockScriptDocRow(): ScriptDocRow {
     project_id: MOCK_PROJECT_ID,
     doc: cloneScriptDoc(),
     revision_id: baseScriptDoc.revision?.id ?? null,
+    record_type: "version",
+    version_number: 1,
+    source_version_id: null,
     created_at: baseScriptDoc.metadata.createdAt,
     updated_at: baseScriptDoc.metadata.updatedAt,
   };

--- a/src/lib/db/projects.ts
+++ b/src/lib/db/projects.ts
@@ -10,6 +10,7 @@ import {
   upsertMockProjectMembership,
 } from "./mocks";
 import { fetchLatestScriptDoc } from "./scriptDocs";
+import type { ScriptDocRecordType } from "./scriptDocs";
 import type { ProjectMemberRow, ProjectRow } from "./schema";
 import type { ScriptDoc } from "@/lib/scriptDoc";
 
@@ -239,6 +240,8 @@ export async function getProject(projectId: string): Promise<ProjectSummary | nu
 export interface StudioHydrationPayload {
   project: ProjectSummary | null;
   scriptDoc: ScriptDoc | null;
+  scriptDocSource: ScriptDocRecordType | null;
+  scriptDocVersionNumber: number | null;
 }
 
 export async function getStudioHydration(
@@ -249,15 +252,22 @@ export async function getStudioHydration(
     return {
       project,
       scriptDoc: getMockScriptDoc(),
+      scriptDocSource: "version",
+      scriptDocVersionNumber: 1,
     };
   }
 
-  const [project, scriptDoc] = await Promise.all([
+  const [project, scriptDocRecord] = await Promise.all([
     getProject(projectId),
-    fetchLatestScriptDoc(projectId),
+    fetchLatestScriptDoc(projectId, { preferAutosave: true }),
   ]);
 
-  return { project, scriptDoc };
+  return {
+    project,
+    scriptDoc: scriptDocRecord?.doc ?? null,
+    scriptDocSource: scriptDocRecord?.recordType ?? null,
+    scriptDocVersionNumber: scriptDocRecord?.versionNumber ?? null,
+  };
 }
 
 export async function createProject(

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -33,6 +33,42 @@ export interface ScriptDocRow {
   project_id: string;
   doc: ScriptDoc;
   revision_id: string | null;
+  record_type: "version" | "autosave";
+  version_number: number | null;
+  source_version_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface BeatRow {
+  id: string;
+  project_id: string;
+  script_doc_id: string | null;
+  beat_id: string;
+  title: string;
+  summary: string | null;
+  intent: string | null;
+  order_index: number;
+  duration_seconds: number | null;
+  spotlight_character_ids: string[] | null;
+  location_ids: string[] | null;
+  reference_asset_ids: string[] | null;
+  payload: unknown;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SceneRow {
+  id: string;
+  project_id: string;
+  script_doc_id: string | null;
+  scene_id: string;
+  beat_id: string | null;
+  title: string | null;
+  summary: string | null;
+  slugline: unknown;
+  order_index: number;
+  payload: unknown;
   created_at: string;
   updated_at: string;
 }
@@ -62,7 +98,7 @@ export interface EntityAssetRow {
   entity_id: string;
   entity_type: EntityAssetTargetType;
   caption: string | null;
-  order: number;
+  order_index: number;
   is_private: boolean;
   created_at: string;
   updated_at: string;

--- a/src/lib/db/scriptDocs.ts
+++ b/src/lib/db/scriptDocs.ts
@@ -1,17 +1,225 @@
 import type { ScriptDoc } from "@/lib/scriptDoc";
 import { getSupabaseClient } from "./client";
 import { isSupabaseConfigured } from "./config";
-import { getMockScriptDoc, getMockScriptDocRow } from "./mocks";
-import type { ScriptDocRow } from "./schema";
+import { getMockScriptDocRow } from "./mocks";
+import type { BeatRow, SceneRow, ScriptDocRow } from "./schema";
 
-function mapScriptDocRow(row: ScriptDocRow): ScriptDoc {
-  return row.doc;
+export type ScriptDocRecordType = ScriptDocRow["record_type"];
+
+export interface ScriptDocRecord {
+  id: string;
+  projectId: string;
+  doc: ScriptDoc;
+  revisionId: string | null;
+  recordType: ScriptDocRecordType;
+  versionNumber: number | null;
+  sourceVersionId: string | null;
+  createdAt: string;
+  updatedAt: string;
 }
 
-export async function fetchLatestScriptDoc(projectId: string): Promise<ScriptDoc | null> {
+const localAutosaves = new Map<string, ScriptDocRecord>();
+const localVersions = new Map<string, ScriptDocRecord[]>();
+
+const cloneDoc = (doc: ScriptDoc): ScriptDoc =>
+  typeof structuredClone === "function"
+    ? structuredClone(doc)
+    : (JSON.parse(JSON.stringify(doc)) as ScriptDoc);
+
+function mapScriptDocRow(row: ScriptDocRow): ScriptDocRecord {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    doc: row.doc,
+    revisionId: row.revision_id,
+    recordType: row.record_type,
+    versionNumber: row.version_number,
+    sourceVersionId: row.source_version_id,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function seedLocalVersion(projectId: string): ScriptDocRecord {
+  const base = mapScriptDocRow(getMockScriptDocRow());
+  const now = new Date().toISOString();
+  const docClone = cloneDoc(base.doc);
+  docClone.metadata = {
+    ...docClone.metadata,
+    projectId,
+  };
+
+  const record: ScriptDocRecord = {
+    ...base,
+    id: `${base.id}-${projectId}`,
+    projectId,
+    doc: docClone,
+    createdAt: now,
+    updatedAt: now,
+  };
+  localVersions.set(projectId, [record]);
+  return record;
+}
+
+function ensureLocalVersion(projectId: string): ScriptDocRecord {
+  const versions = localVersions.get(projectId);
+  if (versions && versions.length > 0) {
+    return versions[versions.length - 1]!;
+  }
+  return seedLocalVersion(projectId);
+}
+
+async function syncBeatsForDoc(
+  projectId: string,
+  scriptDocId: string,
+  doc: ScriptDoc,
+): Promise<void> {
   if (!isSupabaseConfigured()) {
-    const mockRow = getMockScriptDocRow();
-    return mockRow.project_id === projectId ? mapScriptDocRow(mockRow) : getMockScriptDoc();
+    return;
+  }
+
+  const supabase = getSupabaseClient();
+  if (!doc.beats?.length) {
+    return;
+  }
+
+  const beatPayloads = doc.beats.map((beat) => ({
+    project_id: projectId,
+    script_doc_id: scriptDocId,
+    beat_id: beat.id,
+    title: beat.title,
+    summary: beat.summary ?? null,
+    intent: beat.intent ?? null,
+    order_index: beat.order,
+    duration_seconds: beat.durationSeconds ?? null,
+    spotlight_character_ids: beat.spotlightCharacterIds ?? null,
+    location_ids: beat.locationIds ?? null,
+    reference_asset_ids: beat.referenceAssetIds ?? null,
+    payload: beat,
+  } satisfies Partial<BeatRow> & {
+    project_id: string;
+    script_doc_id: string;
+    beat_id: string;
+    title: string;
+    order_index: number;
+  }));
+
+  const { error } = await supabase.from<BeatRow>("beats").insert(beatPayloads);
+  if (error) {
+    console.error("Failed to sync beats for script doc", error);
+    throw error;
+  }
+}
+
+async function syncScenesForDoc(
+  projectId: string,
+  scriptDocId: string,
+  doc: ScriptDoc,
+): Promise<void> {
+  if (!isSupabaseConfigured()) {
+    return;
+  }
+
+  const supabase = getSupabaseClient();
+  if (!doc.scenes?.length) {
+    return;
+  }
+
+  const scenePayloads = doc.scenes.map((scene) => ({
+    project_id: projectId,
+    script_doc_id: scriptDocId,
+    scene_id: scene.id,
+    beat_id: scene.beatId ?? null,
+    title: scene.title ?? null,
+    summary: scene.summary ?? null,
+    slugline: scene.slugline ?? null,
+    order_index: scene.order,
+    payload: scene,
+  } satisfies Partial<SceneRow> & {
+    project_id: string;
+    script_doc_id: string;
+    scene_id: string;
+    order_index: number;
+  }));
+
+  const { error } = await supabase.from<SceneRow>("scenes").insert(scenePayloads);
+  if (error) {
+    console.error("Failed to sync scenes for script doc", error);
+    throw error;
+  }
+}
+
+export interface FetchScriptDocOptions {
+  preferAutosave?: boolean;
+}
+
+export async function fetchLatestScriptDoc(
+  projectId: string,
+  options: FetchScriptDocOptions = {},
+): Promise<ScriptDocRecord | null> {
+  if (!isSupabaseConfigured()) {
+    const autosave = localAutosaves.get(projectId);
+    const latestVersion = ensureLocalVersion(projectId);
+    if (options.preferAutosave && autosave) {
+      return autosave;
+    }
+    return latestVersion;
+  }
+
+  const supabase = getSupabaseClient();
+
+  const [{ data: autosaveRow, error: autosaveError }, { data: versionRow, error: versionError }]
+    = await Promise.all([
+      supabase
+        .from<ScriptDocRow>("script_docs")
+        .select("*")
+        .eq("project_id", projectId)
+        .eq("record_type", "autosave")
+        .order("updated_at", { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+      supabase
+        .from<ScriptDocRow>("script_docs")
+        .select("*")
+        .eq("project_id", projectId)
+        .eq("record_type", "version")
+        .order("version_number", { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+    ]);
+
+  if (autosaveError && autosaveError.code !== "PGRST116") {
+    console.error("Failed to fetch script doc autosave", autosaveError);
+    throw autosaveError;
+  }
+
+  if (versionError && versionError.code !== "PGRST116") {
+    console.error("Failed to fetch script doc version", versionError);
+    throw versionError;
+  }
+
+  if (options.preferAutosave && autosaveRow) {
+    return mapScriptDocRow(autosaveRow);
+  }
+
+  if (versionRow) {
+    return mapScriptDocRow(versionRow);
+  }
+
+  if (autosaveRow) {
+    return mapScriptDocRow(autosaveRow);
+  }
+
+  return null;
+}
+
+export async function listScriptDocVersions(
+  projectId: string,
+  limit = 10,
+): Promise<ScriptDocRecord[]> {
+  if (!isSupabaseConfigured()) {
+    const versions = localVersions.get(projectId) ?? [ensureLocalVersion(projectId)];
+    return versions.slice(-limit);
   }
 
   const supabase = getSupabaseClient();
@@ -19,46 +227,150 @@ export async function fetchLatestScriptDoc(projectId: string): Promise<ScriptDoc
     .from<ScriptDocRow>("script_docs")
     .select("*")
     .eq("project_id", projectId)
-    .order("updated_at", { ascending: false })
-    .limit(1)
-    .maybeSingle();
+    .eq("record_type", "version")
+    .order("version_number", { ascending: false })
+    .limit(limit);
 
   if (error) {
-    if (error.code === "PGRST116") {
-      return null;
-    }
-    console.error("Failed to fetch script doc", error);
+    console.error("Failed to list script doc versions", error);
     throw error;
   }
 
-  return data ? mapScriptDocRow(data) : null;
+  return (data ?? []).map(mapScriptDocRow);
+}
+
+export async function createScriptDocAutosave(
+  projectId: string,
+  doc: ScriptDoc,
+  options: { sourceVersionId?: string | null } = {},
+): Promise<ScriptDocRecord> {
+  if (!isSupabaseConfigured()) {
+    const latest = ensureLocalVersion(projectId);
+    const record: ScriptDocRecord = {
+      ...latest,
+      id: `autosave-${projectId}`,
+      doc,
+      revisionId: doc.revision?.id ?? latest.revisionId ?? null,
+      recordType: "autosave",
+      versionNumber: null,
+      sourceVersionId: options.sourceVersionId ?? latest.id,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    localAutosaves.set(projectId, record);
+    return record;
+  }
+
+  const supabase = getSupabaseClient();
+  const payload = {
+    project_id: projectId,
+    doc,
+    revision_id: doc.revision?.id ?? null,
+    record_type: "autosave" as ScriptDocRecordType,
+    source_version_id: options.sourceVersionId ?? null,
+  } satisfies Partial<ScriptDocRow> & {
+    project_id: string;
+    record_type: ScriptDocRecordType;
+  };
+
+  const { data, error } = await supabase
+    .from<ScriptDocRow>("script_docs")
+    .upsert(payload, { onConflict: "project_id", ignoreDuplicates: false })
+    .select("*")
+    .single();
+
+  if (error) {
+    console.error("Failed to create script doc autosave", error);
+    throw error;
+  }
+
+  return mapScriptDocRow(data);
+}
+
+export async function createScriptDocVersion(
+  projectId: string,
+  doc: ScriptDoc,
+): Promise<ScriptDocRecord> {
+  if (!isSupabaseConfigured()) {
+    const latest = ensureLocalVersion(projectId);
+    const nextVersionNumber = (latest.versionNumber ?? 0) + 1;
+    const now = new Date().toISOString();
+    const record: ScriptDocRecord = {
+      id: `version-${projectId}-${nextVersionNumber}`,
+      projectId,
+      doc,
+      revisionId: doc.revision?.id ?? null,
+      recordType: "version",
+      versionNumber: nextVersionNumber,
+      sourceVersionId: null,
+      createdAt: now,
+      updatedAt: now,
+    };
+    const versions = localVersions.get(projectId) ?? [];
+    versions.push(record);
+    localVersions.set(projectId, versions);
+    localAutosaves.delete(projectId);
+    return record;
+  }
+
+  const supabase = getSupabaseClient();
+  const { data: latestVersion, error: latestError } = await supabase
+    .from<ScriptDocRow>("script_docs")
+    .select("version_number")
+    .eq("project_id", projectId)
+    .eq("record_type", "version")
+    .order("version_number", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (latestError && latestError.code !== "PGRST116") {
+    console.error("Failed to resolve latest script doc version", latestError);
+    throw latestError;
+  }
+
+  const nextVersionNumber = (latestVersion?.version_number ?? 0) + 1;
+
+  const insertPayload = {
+    project_id: projectId,
+    doc,
+    revision_id: doc.revision?.id ?? null,
+    record_type: "version" as ScriptDocRecordType,
+    version_number: nextVersionNumber,
+  } satisfies Partial<ScriptDocRow> & {
+    project_id: string;
+    record_type: ScriptDocRecordType;
+    version_number: number;
+  };
+
+  const { data, error } = await supabase
+    .from<ScriptDocRow>("script_docs")
+    .insert(insertPayload)
+    .select("*")
+    .single();
+
+  if (error) {
+    console.error("Failed to create script doc version", error);
+    throw error;
+  }
+
+  await Promise.all([
+    syncBeatsForDoc(projectId, data.id, doc),
+    syncScenesForDoc(projectId, data.id, doc),
+  ]);
+
+  await supabase
+    .from<ScriptDocRow>("script_docs")
+    .delete()
+    .eq("project_id", projectId)
+    .eq("record_type", "autosave");
+
+  return mapScriptDocRow(data);
 }
 
 export async function upsertScriptDoc(
   projectId: string,
   doc: ScriptDoc,
 ): Promise<ScriptDoc> {
-  if (!isSupabaseConfigured()) {
-    return getMockScriptDoc();
-  }
-
-  const supabase = getSupabaseClient();
-  const payload: Partial<ScriptDocRow> & { project_id: string } = {
-    project_id: projectId,
-    doc,
-    revision_id: doc.revision?.id ?? null,
-  };
-
-  const { data, error } = await supabase
-    .from<ScriptDocRow>("script_docs")
-    .upsert(payload, { onConflict: "project_id" })
-    .select("*")
-    .single();
-
-  if (error) {
-    console.error("Failed to upsert script doc", error);
-    throw error;
-  }
-
-  return mapScriptDocRow(data);
+  const record = await createScriptDocVersion(projectId, doc);
+  return record.doc;
 }

--- a/src/lib/state/scriptDocStore.ts
+++ b/src/lib/state/scriptDocStore.ts
@@ -2,8 +2,6 @@
 
 import { create } from "zustand";
 
-import { getMockScriptDoc } from "@/lib/db/mocks";
-
 import {
   ScriptDoc,
   ScriptDocBeat,
@@ -11,6 +9,73 @@ import {
   ScriptSceneElement,
   type ScriptDocTranscriptEntry,
 } from "@/lib/scriptDoc";
+
+const AUTOSAVE_DEBOUNCE_MS = 1500;
+
+let autosaveTimer: ReturnType<typeof setTimeout> | null = null;
+let autosaveReady = false;
+let autosaveProjectId: string | null = null;
+let lastAutosaveDigest: string | null = null;
+let autosaveDisabled = false;
+
+const encodeDoc = (doc: ScriptDoc) => JSON.stringify(doc);
+
+async function sendAutosave(projectId: string, doc: ScriptDoc) {
+  if (typeof window === "undefined" || autosaveDisabled || !projectId) {
+    return;
+  }
+
+  try {
+    const response = await fetch(
+      `/api/projects/${encodeURIComponent(projectId)}/script-doc/autosave`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ doc }),
+      },
+    );
+
+    if (!response.ok) {
+      if ([401, 403, 404, 501, 503].includes(response.status)) {
+        autosaveDisabled = true;
+      }
+      const message = await response.text();
+      console.error("ScriptDoc autosave failed", message);
+    }
+  } catch (error) {
+    console.error("Failed to autosave ScriptDoc", error);
+  }
+}
+
+function scheduleAutosave(doc: ScriptDoc) {
+  if (
+    typeof window === "undefined" ||
+    autosaveDisabled ||
+    !autosaveReady ||
+    !doc.metadata?.projectId
+  ) {
+    return;
+  }
+
+  const serialized = encodeDoc(doc);
+  if (serialized === lastAutosaveDigest) {
+    return;
+  }
+
+  lastAutosaveDigest = serialized;
+  autosaveProjectId = doc.metadata.projectId;
+
+  if (autosaveTimer) {
+    clearTimeout(autosaveTimer);
+  }
+
+  autosaveTimer = setTimeout(() => {
+    if (autosaveProjectId) {
+      void sendAutosave(autosaveProjectId, doc);
+    }
+  }, AUTOSAVE_DEBOUNCE_MS);
+}
 
 type ScriptDocHistoryState = {
   doc: ScriptDoc;
@@ -435,6 +500,11 @@ export const useScriptDocStore = create<ScriptDocStore>((set, get) => ({
       hasUndo: false,
       hasRedo: false,
     });
+    if (typeof window !== "undefined") {
+      autosaveReady = true;
+      autosaveProjectId = cloned.metadata?.projectId ?? null;
+      lastAutosaveDigest = encodeDoc(cloned);
+    }
   },
   updateMetadata: (updates) => {
     const state = get();
@@ -674,4 +744,13 @@ export const selectBeats = (state: ScriptDocStore) =>
 
 export const selectScenes = (state: ScriptDocStore) =>
   [...state.doc.scenes].sort((a, b) => a.order - b.order);
+
+if (typeof window !== "undefined") {
+  useScriptDocStore.subscribe(
+    (state) => state.doc,
+    (doc) => {
+      scheduleAutosave(doc);
+    },
+  );
+}
 

--- a/supabase/migrations/20240211000000_create_voice_script_tables.sql
+++ b/supabase/migrations/20240211000000_create_voice_script_tables.sql
@@ -1,0 +1,115 @@
+-- Voice Script Studio core tables
+-- Derived from docs/voice-script-studio-development.md
+
+create extension if not exists "pgcrypto";
+
+create table if not exists public.projects (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  script_type text not null,
+  genre text,
+  logline text,
+  status text not null default 'draft',
+  owner_id uuid,
+  tags text[] default array[]::text[],
+  target_length_unit text check (target_length_unit in ('pages','minutes','seconds')),
+  target_length_value numeric,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.script_docs (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.projects(id) on delete cascade,
+  doc jsonb not null,
+  revision_id uuid,
+  record_type text not null check (record_type in ('version','autosave')),
+  version_number integer,
+  source_version_id uuid references public.script_docs(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create unique index if not exists script_docs_unique_version
+  on public.script_docs(project_id, version_number)
+  where record_type = 'version';
+
+create unique index if not exists script_docs_unique_autosave
+  on public.script_docs(project_id)
+  where record_type = 'autosave';
+
+create table if not exists public.beats (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.projects(id) on delete cascade,
+  script_doc_id uuid references public.script_docs(id) on delete cascade,
+  beat_id text not null,
+  title text not null,
+  summary text,
+  intent text,
+  order_index integer not null,
+  duration_seconds integer,
+  spotlight_character_ids text[] default array[]::text[],
+  location_ids text[] default array[]::text[],
+  reference_asset_ids text[] default array[]::text[],
+  payload jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists beats_project_doc_idx
+  on public.beats(project_id, script_doc_id, order_index);
+
+create table if not exists public.scenes (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.projects(id) on delete cascade,
+  script_doc_id uuid references public.script_docs(id) on delete cascade,
+  scene_id text not null,
+  beat_id text,
+  title text,
+  summary text,
+  slugline jsonb,
+  order_index integer not null,
+  payload jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists scenes_project_doc_idx
+  on public.scenes(project_id, script_doc_id, order_index);
+
+create table if not exists public.reference_assets (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid references public.projects(id) on delete cascade,
+  name text not null,
+  description text,
+  source_type text not null check (source_type in ('upload','external','link')),
+  url text not null,
+  thumbnail_url text,
+  preview_color text,
+  content_type text not null,
+  size bigint not null,
+  tags text[] default array[]::text[],
+  status text not null default 'pending' check (status in ('pending','ready')),
+  attribution text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists reference_assets_project_idx
+  on public.reference_assets(project_id, status);
+
+create table if not exists public.entity_assets (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.projects(id) on delete cascade,
+  asset_id uuid not null references public.reference_assets(id) on delete cascade,
+  entity_id text not null,
+  entity_type text not null,
+  caption text,
+  order_index integer not null default 0,
+  is_private boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists entity_assets_project_entity_idx
+  on public.entity_assets(project_id, entity_type, entity_id, order_index);


### PR DESCRIPTION
## Summary
- add Supabase migrations for projects, script_docs, beats, scenes, reference assets, and entity assets
- expand the script doc data layer to support Supabase-backed autosave and version creation with beat/scene synchronization
- expose autosave/version API routes and hook the studio Zustand store into the new persistence endpoints

## Testing
- npm run lint *(fails: Next.js CLI unavailable because dependencies cannot be installed in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69143b48b33083229ee16a04f47af34e)