### PR TITLE
feat: add resilient realtime orchestrator service

### DIFF
--- a/src/app/api/realtime/orchestrator/route.ts
+++ b/src/app/api/realtime/orchestrator/route.ts
@@ -1,457 +1,26 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { parseToolAcknowledgement } from "@/lib/realtime/schema";
+import { ProjectAuthorizationError } from "@/lib/authz/projects.server";
+import { UnauthorizedError } from "@/lib/auth/server";
 import {
-  TOOL_DEFINITIONS,
-  parseToolAcknowledgement,
-  parseToolInvocationPayload,
-  type OrchestratorSessionMetadata,
-  type ToolAcknowledgement,
-  type TranscriptTurnDTO,
-  validateToolInvocationPayload,
-} from "@/lib/realtime/schema";
+  RateLimitExceededError,
+  requireRealtimeContext,
+} from "@/lib/orchestrator/middleware.server";
 import {
-  fetchSessionMetadata,
-  fetchTranscriptTurns,
-  persistProjectStatePatch,
-  persistSessionMetadata,
-  persistTranscriptTurn,
-} from "@/lib/transcripts.server";
-import { requireServerAuthSession, UnauthorizedError } from "@/lib/auth/server";
-import {
-  ensureProjectMembership,
-  ProjectAuthorizationError,
-} from "@/lib/authz/projects.server";
-import { enforceRateLimit } from "@/lib/rateLimit";
-import { logAuditEvent } from "@/lib/auditLog";
-
-const DEFAULT_REALTIME_MODEL = process.env.OPENAI_REALTIME_MODEL ?? "gpt-4o-realtime-preview-2024-12-10";
-const DEFAULT_REALTIME_VOICE = process.env.OPENAI_REALTIME_VOICE ?? "verse";
-const MODERATION_MODEL = process.env.OPENAI_MODERATION_MODEL ?? "omni-moderation-latest";
-
-interface SessionCacheEntry {
-  ackToken: string;
-  projectId?: string;
-  expiresAt?: string;
-}
-
-const sessionCache = new Map<string, SessionCacheEntry>();
+  RealtimeOrchestratorError,
+  getRealtimeOrchestratorService,
+} from "@/lib/orchestrator/service.server";
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && Object.getPrototypeOf(value) === Object.prototype;
 }
 
-async function ensureSessionCache(sessionId: string): Promise<SessionCacheEntry | null> {
-  if (sessionCache.has(sessionId)) {
-    return sessionCache.get(sessionId)!;
-  }
-
-  try {
-    const metadata = await fetchSessionMetadata(sessionId);
-    if (metadata?.ackToken) {
-      const entry: SessionCacheEntry = {
-        ackToken: metadata.ackToken,
-        projectId: metadata.projectId,
-        expiresAt: metadata.expiresAt,
-      };
-      sessionCache.set(sessionId, entry);
-      return entry;
-    }
-  } catch (error) {
-    console.warn("Failed to hydrate session cache from Supabase", error);
-  }
-
-  return null;
-}
-
-async function moderateText(text: string) {
-  if (!text?.trim()) {
-    return { flagged: false } as const;
-  }
-
-  const apiKey = process.env.OPENAI_API_KEY;
-  if (!apiKey) {
-    return { flagged: false } as const;
-  }
-
-  try {
-    const response = await fetch("https://api.openai.com/v1/moderations", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ model: MODERATION_MODEL, input: text }),
-    });
-
-    if (!response.ok) {
-      console.warn("Moderation request failed", response.status, await response.text());
-      return { flagged: false } as const;
-    }
-
-    const payload = (await response.json()) as { results?: Array<{ flagged?: boolean }> };
-    const flagged = Boolean(payload.results?.some((result) => result.flagged));
-    return { flagged } as const;
-  } catch (error) {
-    console.warn("Moderation request error", error);
-    return { flagged: false } as const;
-  }
-}
-
-async function createRealtimeSession(body: Record<string, unknown>) {
-  const apiKey = process.env.OPENAI_API_KEY;
-  if (!apiKey) {
-    throw new Error("OPENAI_API_KEY is not configured");
-  }
-
-  const response = await fetch("https://api.openai.com/v1/realtime/sessions", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(body),
-  });
-
-  const payload = await response.json();
-  if (!response.ok) {
-    const message =
-      typeof payload === "object" && payload && "error" in payload
-        ? (payload.error as { message?: string }).message ?? "OpenAI realtime session error"
-        : "Failed to create realtime session";
-    throw new Error(message);
-  }
-
-  return payload as Record<string, unknown>;
-}
-
-function normalizeSessionMetadata(
-  session: Record<string, unknown>,
-  projectId: string | undefined,
-  ackToken: string,
-): OrchestratorSessionMetadata {
-  const sessionId = typeof session.id === "string" ? session.id : crypto.randomUUID();
-  const expiresAt = typeof session.expires_at === "string" ? session.expires_at : undefined;
-
-  const metadata: OrchestratorSessionMetadata = {
-    sessionId,
-    ackToken,
-    projectId,
-    expiresAt,
-    toolSchemas: TOOL_DEFINITIONS,
-    transcripts: [],
-  };
-
-  sessionCache.set(sessionId, { ackToken, projectId, expiresAt });
-  return metadata;
-}
-
-async function handleSessionCreate(
-  request: NextRequest,
-  payload: Record<string, unknown>,
-  userId: string,
-) {
-  const projectId = typeof payload.projectId === "string" ? payload.projectId : undefined;
-  const requestedSessionId = typeof payload.sessionId === "string" ? payload.sessionId : undefined;
-
-  const session = await createRealtimeSession({
-    model: DEFAULT_REALTIME_MODEL,
-    voice: DEFAULT_REALTIME_VOICE,
-    instructions:
-      "Use update_project_state to synchronize ScriptDoc patches and log_transcript_turn to persist transcript updates.",
-    tools: TOOL_DEFINITIONS.map((tool) => ({
-      type: "function",
-      name: tool.name,
-      description: tool.description,
-      parameters: tool.schema,
-    })),
-  });
-
-  const ackToken = crypto.randomUUID();
-  const metadata = normalizeSessionMetadata(session, projectId, ackToken);
-  if (requestedSessionId && requestedSessionId !== metadata.sessionId) {
-    metadata.sessionId = requestedSessionId;
-    sessionCache.set(requestedSessionId, {
-      ackToken,
-      projectId,
-      expiresAt: metadata.expiresAt,
-    });
-  }
-
-  try {
-    await persistSessionMetadata({
-      sessionId: metadata.sessionId,
-      projectId,
-      ackToken,
-      expiresAt: metadata.expiresAt ?? null,
-      rawSession: session,
-      orchestratorSessionId: requestedSessionId ?? null,
-    });
-  } catch (error) {
-    console.warn("Failed to persist realtime session metadata", error);
-  }
-
-  try {
-    const existing = await fetchTranscriptTurns(metadata.sessionId, 200);
-    metadata.transcripts = existing;
-  } catch (error) {
-    console.warn("Failed to hydrate transcript history", error);
-  }
-
-  await logAuditEvent({
-    action: "realtime.session.create",
-    userId,
-    projectId,
-    targetId: metadata.sessionId,
-    details: { requestedSessionId, expiresAt: metadata.expiresAt },
-  });
-
-  return NextResponse.json(
-    { session, metadata },
-    {
-      status: 200,
-      headers: {
-        "Cache-Control": "no-store",
-      },
-    },
-  );
-}
-
-function parseTranscriptTurn(payload: unknown): TranscriptTurnDTO | null {
-  if (!isPlainObject(payload)) {
-    return null;
-  }
-
-  const id = typeof payload.id === "string" ? payload.id : null;
-  const role = typeof payload.role === "string" ? payload.role : null;
-  const text = typeof payload.text === "string" ? payload.text : null;
-  const final = typeof payload.final === "boolean" ? payload.final : null;
-  const createdAt = typeof payload.createdAt === "string" ? payload.createdAt : null;
-
-  if (!id || !role || !text || final === null || !createdAt) {
-    return null;
-  }
-
-  const projectId = typeof payload.projectId === "string" ? payload.projectId : undefined;
-
-  return {
-    id,
-    role,
-    text,
-    final,
-    createdAt,
-    projectId,
-  };
-}
-
-async function handleTranscriptAppend(payload: Record<string, unknown>, userId: string) {
-  const sessionId = typeof payload.sessionId === "string" ? payload.sessionId : null;
-  const ackToken = typeof payload.ackToken === "string" ? payload.ackToken : null;
-  const turn = parseTranscriptTurn(payload.turn);
-
-  if (!sessionId || !ackToken || !turn) {
-    return NextResponse.json({ error: "Invalid transcript payload" }, { status: 400 });
-  }
-
-  const entry = (await ensureSessionCache(sessionId)) ?? undefined;
-  if (!entry || entry.ackToken !== ackToken) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const { flagged } = await moderateText(turn.text);
-  if (flagged) {
-    return NextResponse.json({ error: "Transcript failed moderation" }, { status: 400 });
-  }
-
-  const projectId = turn.projectId ?? entry.projectId;
-  if (projectId) {
-    await ensureProjectMembership(projectId, userId, { minimumRole: "member" });
-  }
-
-  try {
-    await persistTranscriptTurn({ ...turn, sessionId, projectId });
-  } catch (error) {
-    console.warn("Failed to persist transcript turn", error);
-    return NextResponse.json({ error: "Unable to persist transcript" }, { status: 500 });
-  }
-
-  await logAuditEvent({
-    action: "transcript.turn.append",
-    userId,
-    projectId: projectId ?? undefined,
-    targetId: turn.id,
-    details: { role: turn.role, final: turn.final },
-  });
-
-  return NextResponse.json(
-    {
-      acknowledgement: {
-        requestId: turn.id,
-        status: "accepted",
-        timestamp: new Date().toISOString(),
-        transcriptTurn: { ...turn, sessionId },
-      } satisfies ToolAcknowledgement,
-    },
-    { status: 200 },
-  );
-}
-
-async function dispatchToolInvocation(
-  payload: Record<string, unknown>,
-  userId: string,
-): Promise<NextResponse<ToolAcknowledgement | { error: string }>> {
-  const sessionId = typeof payload.sessionId === "string" ? payload.sessionId : null;
-  const ackToken = typeof payload.ackToken === "string" ? payload.ackToken : null;
-  const rawInvocation = payload.invocation;
-
-  if (!sessionId || !ackToken || !rawInvocation) {
-    return NextResponse.json({ error: "Invalid tool invocation" }, { status: 400 });
-  }
-
-  const entry = await ensureSessionCache(sessionId);
-  if (!entry || entry.ackToken !== ackToken) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const invocation = parseToolInvocationPayload(rawInvocation);
-  if (!invocation) {
-    return NextResponse.json({ error: "Malformed tool invocation" }, { status: 400 });
-  }
-
-  invocation.sessionId = sessionId;
-  invocation.projectId = typeof payload.projectId === "string" ? payload.projectId : entry.projectId;
-
-  if (invocation.projectId) {
-    await ensureProjectMembership(invocation.projectId, userId, { minimumRole: "member" });
-  }
-
-  const validationErrors = validateToolInvocationPayload(invocation);
-  if (validationErrors.length > 0) {
-    return NextResponse.json({ error: validationErrors.join("; ") }, { status: 400 });
-  }
-
-  const acknowledgement: ToolAcknowledgement = {
-    requestId: invocation.callId,
-    status: "accepted",
-    timestamp: new Date().toISOString(),
-  };
-
-  if (invocation.name === "log_transcript_turn") {
-    const turn = parseTranscriptTurn(invocation.arguments);
-    if (!turn) {
-      return NextResponse.json({ error: "Invalid transcript payload" }, { status: 400 });
-    }
-
-    const { flagged } = await moderateText(turn.text);
-    if (flagged) {
-      acknowledgement.status = "rejected";
-      acknowledgement.reason = "Transcript failed moderation";
-      return NextResponse.json(acknowledgement, { status: 400 });
-    }
-
-    const projectId = turn.projectId ?? invocation.projectId;
-    try {
-      await persistTranscriptTurn({ ...turn, sessionId, projectId });
-      acknowledgement.transcriptTurn = { ...turn, sessionId };
-    } catch (error) {
-      console.warn("Failed to persist transcript turn", error);
-      return NextResponse.json({ error: "Unable to persist transcript" }, { status: 500 });
-    }
-
-    await logAuditEvent({
-      action: "transcript.turn.append",
-      userId,
-      projectId: projectId ?? undefined,
-      targetId: turn.id,
-      details: { role: turn.role, final: turn.final },
-    });
-
-    return NextResponse.json(acknowledgement, { status: 200 });
-  }
-
-  if (invocation.name === "update_project_state") {
-    const patch = isPlainObject(invocation.arguments) ? invocation.arguments.patch ?? invocation.arguments : null;
-    if (!patch || !isPlainObject(patch)) {
-      return NextResponse.json({ error: "Invalid project state patch" }, { status: 400 });
-    }
-
-    const reason = isPlainObject(invocation.arguments) && typeof invocation.arguments.reason === "string"
-      ? invocation.arguments.reason
-      : undefined;
-
-    try {
-      await persistProjectStatePatch({
-        sessionId,
-        projectId: invocation.projectId,
-        patch,
-        reason,
-      });
-      acknowledgement.projectStatePatch = patch;
-    } catch (error) {
-      console.warn("Failed to persist project state patch", error);
-      return NextResponse.json({ error: "Unable to persist project state" }, { status: 500 });
-    }
-
-    await logAuditEvent({
-      action: "project.state.patch",
-      userId,
-      projectId: invocation.projectId ?? undefined,
-      targetId: sessionId,
-      details: { reason },
-      severity: "high",
-    });
-
-    return NextResponse.json(acknowledgement, { status: 200 });
-  }
-
-  acknowledgement.status = "rejected";
-  acknowledgement.reason = `Unsupported tool: ${invocation.name}`;
-  return NextResponse.json(acknowledgement, { status: 400 });
-}
-
-async function handleTranscriptFetch(payload: Record<string, unknown>, userId: string) {
-  const sessionId = typeof payload.sessionId === "string" ? payload.sessionId : null;
-  if (!sessionId) {
-    return NextResponse.json({ error: "sessionId is required" }, { status: 400 });
-  }
-
-  try {
-    const entry = await ensureSessionCache(sessionId);
-    if (entry?.projectId) {
-      await ensureProjectMembership(entry.projectId, userId);
-    }
-
-    const transcripts = await fetchTranscriptTurns(sessionId, 200);
-    return NextResponse.json({ transcripts }, { status: 200 });
-  } catch (error) {
-    console.warn("Failed to load transcripts", error);
-    return NextResponse.json({ error: "Unable to load transcripts" }, { status: 500 });
-  }
-}
-
 export async function POST(request: NextRequest) {
-  try {
-    const { user } = await requireServerAuthSession();
-    const rate = await enforceRateLimit({
-      key: user.id,
-      limit: 120,
-      windowMs: 60_000,
-      prefix: "realtime:orchestrator",
-    });
+  const orchestrator = getRealtimeOrchestratorService();
 
-    if (!rate.allowed) {
-      return NextResponse.json(
-        { error: "Rate limit exceeded" },
-        {
-          status: 429,
-          headers: {
-            "Retry-After": Math.max(
-              1,
-              Math.ceil((rate.resetAt - Date.now()) / 1000),
-            ).toString(),
-          },
-        },
-      );
-    }
+  try {
+    const { userId } = await requireRealtimeContext();
 
     let payload: unknown;
     try {
@@ -464,28 +33,44 @@ export async function POST(request: NextRequest) {
     const action = typeof data.action === "string" ? data.action : "session.create";
 
     if (action === "session.create") {
-      if (typeof data.projectId === "string") {
-        await ensureProjectMembership(data.projectId, user.id, { minimumRole: "member" });
-      }
+      const result = await orchestrator.createSession({
+        userId,
+        projectId: typeof data.projectId === "string" ? data.projectId : undefined,
+        requestedSessionId: typeof data.sessionId === "string" ? data.sessionId : undefined,
+      });
 
-      try {
-        return await handleSessionCreate(request, data, user.id);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : "Failed to create session";
-        return NextResponse.json({ error: message }, { status: 502 });
-      }
+      return NextResponse.json(result, {
+        status: 200,
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      });
     }
 
     if (action === "transcript.append") {
-      return handleTranscriptAppend(data, user.id);
-    }
-
-    if (action === "transcript.fetch") {
-      return handleTranscriptFetch(data, user.id);
+      const acknowledgement = await orchestrator.appendTranscript({ payload: data, userId });
+      return NextResponse.json({ acknowledgement }, { status: 200 });
     }
 
     if (action === "tool.invoke") {
-      return dispatchToolInvocation(data, user.id);
+      const acknowledgement = await orchestrator.invokeTool({ payload: data, userId });
+      const status = acknowledgement.status === "accepted" ? 200 : 400;
+      return NextResponse.json(acknowledgement, { status });
+    }
+
+    if (action === "transcript.fetch") {
+      const sessionId = typeof data.sessionId === "string" ? data.sessionId : null;
+      if (!sessionId) {
+        return NextResponse.json({ error: "sessionId is required" }, { status: 400 });
+      }
+
+      const limit =
+        typeof data.limit === "number" && Number.isFinite(data.limit) && data.limit > 0
+          ? Math.min(500, Math.floor(data.limit))
+          : 200;
+
+      const transcripts = await orchestrator.fetchTranscripts({ sessionId, userId, limit });
+      return NextResponse.json({ transcripts }, { status: 200 });
     }
 
     if (action === "ack.parse") {
@@ -498,12 +83,28 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ error: "Unsupported action" }, { status: 400 });
   } catch (error) {
+    if (error instanceof RateLimitExceededError) {
+      return NextResponse.json(
+        { error: error.message },
+        {
+          status: 429,
+          headers: { "Retry-After": error.retryAfter.toString() },
+        },
+      );
+    }
+
     if (error instanceof UnauthorizedError) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
+
     if (error instanceof ProjectAuthorizationError) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
+
+    if (error instanceof RealtimeOrchestratorError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+
     console.error("Realtime orchestrator error", error);
     return NextResponse.json({ error: "Unexpected orchestrator error" }, { status: 500 });
   }

--- a/src/app/studio/voice-chat-panel.tsx
+++ b/src/app/studio/voice-chat-panel.tsx
@@ -335,12 +335,22 @@ export function VoiceChatPanel() {
         return;
       }
 
+      if (event.type === "tool-error") {
+        setError(event.error.message);
+        console.warn("Realtime tool error", event.error);
+        return;
+      }
+
       if (event.type === "session-metadata") {
         const previousSessionId = sessionMetadataRef.current?.sessionId;
         sessionMetadataRef.current = event.metadata ?? null;
 
         if (!event.metadata) {
           return;
+        }
+
+        if (event.metadata.projectStatePatch) {
+          applyScriptDocPatch(event.metadata.projectStatePatch);
         }
 
         if (!previousSessionId || previousSessionId !== event.metadata.sessionId) {

--- a/src/lib/orchestrator/middleware.server.ts
+++ b/src/lib/orchestrator/middleware.server.ts
@@ -1,0 +1,79 @@
+import { requireServerAuthSession } from "@/lib/auth/server";
+import { enforceRateLimit, type RateLimitResult } from "@/lib/rateLimit";
+
+const MODERATION_MODEL = process.env.OPENAI_MODERATION_MODEL ?? "omni-moderation-latest";
+
+export class RateLimitExceededError extends Error {
+  readonly retryAfter: number;
+
+  constructor(message: string, retryAfter: number) {
+    super(message);
+    this.name = "RateLimitExceededError";
+    this.retryAfter = retryAfter;
+  }
+}
+
+export interface RealtimeRequestContext {
+  userId: string;
+  rateLimit: RateLimitResult;
+}
+
+interface RateLimitOptions {
+  key?: string;
+  limit?: number;
+  windowMs?: number;
+  cost?: number;
+  prefix?: string;
+}
+
+export async function requireRealtimeContext(options?: RateLimitOptions): Promise<RealtimeRequestContext> {
+  const { user } = await requireServerAuthSession();
+  const rate = await enforceRateLimit({
+    key: options?.key ?? user.id,
+    limit: options?.limit ?? 120,
+    windowMs: options?.windowMs ?? 60_000,
+    cost: options?.cost,
+    prefix: options?.prefix ?? "realtime:orchestrator",
+  });
+
+  if (!rate.allowed) {
+    const retryAfter = Math.max(1, Math.ceil((rate.resetAt - Date.now()) / 1000));
+    throw new RateLimitExceededError("Rate limit exceeded", retryAfter);
+  }
+
+  return { userId: user.id, rateLimit: rate };
+}
+
+export async function moderateRealtimeText(text: string): Promise<{ flagged: boolean }> {
+  if (!text?.trim()) {
+    return { flagged: false } as const;
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return { flagged: false } as const;
+  }
+
+  try {
+    const response = await fetch("https://api.openai.com/v1/moderations", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ model: MODERATION_MODEL, input: text }),
+    });
+
+    if (!response.ok) {
+      console.warn("Moderation request failed", response.status, await response.text().catch(() => ""));
+      return { flagged: false } as const;
+    }
+
+    const payload = (await response.json()) as { results?: Array<{ flagged?: boolean }> };
+    const flagged = Boolean(payload.results?.some((result) => result.flagged));
+    return { flagged } as const;
+  } catch (error) {
+    console.warn("Moderation request error", error);
+    return { flagged: false } as const;
+  }
+}

--- a/src/lib/orchestrator/service.server.ts
+++ b/src/lib/orchestrator/service.server.ts
@@ -1,0 +1,415 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  TOOL_DEFINITIONS,
+  parseToolInvocationPayload,
+  type OrchestratorSessionMetadata,
+  type ToolAcknowledgement,
+  type TranscriptTurnDTO,
+  validateToolInvocationPayload,
+} from "@/lib/realtime/schema";
+import {
+  fetchSessionMetadata,
+  fetchTranscriptTurns,
+  persistProjectStatePatch,
+  persistSessionMetadata,
+  persistTranscriptTurn,
+} from "@/lib/transcripts.server";
+import { ensureProjectMembership } from "@/lib/authz/projects.server";
+import { logAuditEvent } from "@/lib/auditLog";
+import { moderateRealtimeText } from "./middleware.server";
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && Object.getPrototypeOf(value) === Object.prototype;
+}
+
+interface SessionCacheEntry {
+  ackToken: string;
+  projectId?: string;
+  expiresAt?: string;
+}
+
+export class RealtimeOrchestratorError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status = 400) {
+    super(message);
+    this.name = "RealtimeOrchestratorError";
+    this.status = status;
+  }
+}
+
+async function createRealtimeSession(body: Record<string, unknown>) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new RealtimeOrchestratorError("OPENAI_API_KEY is not configured", 500);
+  }
+
+  const response = await fetch("https://api.openai.com/v1/realtime/sessions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  const payload = await response.json();
+  if (!response.ok) {
+    const message =
+      typeof payload === "object" && payload && "error" in payload
+        ? ((payload as { error?: { message?: string } }).error?.message ?? "OpenAI realtime session error")
+        : "Failed to create realtime session";
+    throw new RealtimeOrchestratorError(message, response.status === 401 ? 401 : 502);
+  }
+
+  return payload as Record<string, unknown>;
+}
+
+function normalizeSessionMetadata(
+  session: Record<string, unknown>,
+  projectId: string | undefined,
+  ackToken: string,
+): OrchestratorSessionMetadata {
+  const sessionId = typeof session.id === "string" ? session.id : randomUUID();
+  const expiresAt = typeof session.expires_at === "string" ? session.expires_at : undefined;
+
+  return {
+    sessionId,
+    ackToken,
+    projectId,
+    expiresAt,
+    toolSchemas: TOOL_DEFINITIONS,
+    transcripts: [],
+  } satisfies OrchestratorSessionMetadata;
+}
+
+function parseTranscriptTurn(value: unknown): (TranscriptTurnDTO & { projectId?: string }) | null {
+  if (!isPlainObject(value)) {
+    return null;
+  }
+
+  const id = typeof value.id === "string" ? value.id : null;
+  const role = typeof value.role === "string" ? value.role : null;
+  const text = typeof value.text === "string" ? value.text : null;
+  const final = typeof value.final === "boolean" ? value.final : null;
+  const createdAt = typeof value.createdAt === "string" ? value.createdAt : null;
+
+  if (!id || !role || !text || final === null || !createdAt) {
+    return null;
+  }
+
+  const projectId = typeof value.projectId === "string" ? value.projectId : undefined;
+
+  return {
+    id,
+    role,
+    text,
+    final,
+    createdAt,
+    projectId,
+  };
+}
+
+export interface CreateSessionInput {
+  userId: string;
+  projectId?: string;
+  requestedSessionId?: string | null;
+}
+
+export interface AppendTranscriptInput {
+  payload: Record<string, unknown>;
+  userId: string;
+}
+
+export interface ToolInvocationInput {
+  payload: Record<string, unknown>;
+  userId: string;
+}
+
+export interface TranscriptFetchInput {
+  sessionId: string;
+  userId: string;
+  limit?: number;
+}
+
+export class RealtimeOrchestratorService {
+  private readonly sessionCache = new Map<string, SessionCacheEntry>();
+
+  async createSession(input: CreateSessionInput): Promise<{ session: Record<string, unknown>; metadata: OrchestratorSessionMetadata }>
+  {
+    if (input.projectId) {
+      await ensureProjectMembership(input.projectId, input.userId, { minimumRole: "member" });
+    }
+
+    const session = await createRealtimeSession({
+      model: process.env.OPENAI_REALTIME_MODEL ?? "gpt-4o-realtime-preview-2024-12-10",
+      voice: process.env.OPENAI_REALTIME_VOICE ?? "verse",
+      instructions:
+        "Use update_project_state to synchronize ScriptDoc patches and log_transcript_turn to persist transcript updates.",
+      tools: TOOL_DEFINITIONS.map((tool) => ({
+        type: "function",
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.schema,
+      })),
+    });
+
+    const ackToken = randomUUID();
+    const metadata = normalizeSessionMetadata(session, input.projectId, ackToken);
+
+    if (input.requestedSessionId && input.requestedSessionId !== metadata.sessionId) {
+      metadata.sessionId = input.requestedSessionId;
+    }
+
+    this.sessionCache.set(metadata.sessionId, {
+      ackToken,
+      projectId: metadata.projectId,
+      expiresAt: metadata.expiresAt,
+    });
+
+    try {
+      await persistSessionMetadata({
+        sessionId: metadata.sessionId,
+        projectId: metadata.projectId,
+        ackToken,
+        expiresAt: metadata.expiresAt ?? null,
+        rawSession: session,
+        orchestratorSessionId: input.requestedSessionId ?? null,
+      });
+    } catch (error) {
+      console.warn("Failed to persist realtime session metadata", error);
+    }
+
+    try {
+      metadata.transcripts = await fetchTranscriptTurns(metadata.sessionId, 200);
+    } catch (error) {
+      console.warn("Failed to hydrate transcript history", error);
+    }
+
+    await logAuditEvent({
+      action: "realtime.session.create",
+      userId: input.userId,
+      projectId: input.projectId,
+      targetId: metadata.sessionId,
+      details: { requestedSessionId: input.requestedSessionId ?? null, expiresAt: metadata.expiresAt },
+    });
+
+    return { session, metadata };
+  }
+
+  async appendTranscript(input: AppendTranscriptInput): Promise<ToolAcknowledgement> {
+    const sessionId = typeof input.payload.sessionId === "string" ? input.payload.sessionId : null;
+    const ackToken = typeof input.payload.ackToken === "string" ? input.payload.ackToken : null;
+    const turn = parseTranscriptTurn(input.payload.turn);
+
+    if (!sessionId || !ackToken || !turn) {
+      throw new RealtimeOrchestratorError("Invalid transcript payload", 400);
+    }
+
+    const entry = await this.requireSessionEntry(sessionId, ackToken);
+
+    if (turn.projectId) {
+      await ensureProjectMembership(turn.projectId, input.userId, { minimumRole: "member" });
+    } else if (entry.projectId) {
+      await ensureProjectMembership(entry.projectId, input.userId, { minimumRole: "member" });
+    }
+
+    const { flagged } = await moderateRealtimeText(turn.text);
+    if (flagged) {
+      throw new RealtimeOrchestratorError("Transcript failed moderation", 400);
+    }
+
+    const projectId = turn.projectId ?? entry.projectId;
+    try {
+      await persistTranscriptTurn({ ...turn, sessionId, projectId });
+    } catch (error) {
+      console.warn("Failed to persist transcript turn", error);
+      throw new RealtimeOrchestratorError("Unable to persist transcript", 500);
+    }
+
+    this.sessionCache.set(sessionId, { ...entry, projectId });
+
+    await logAuditEvent({
+      action: "transcript.turn.append",
+      userId: input.userId,
+      projectId: projectId ?? undefined,
+      targetId: turn.id,
+      details: { role: turn.role, final: turn.final },
+    });
+
+    return {
+      requestId: turn.id,
+      status: "accepted",
+      timestamp: new Date().toISOString(),
+      transcriptTurn: { ...turn, sessionId, projectId },
+    } satisfies ToolAcknowledgement;
+  }
+
+  async invokeTool(input: ToolInvocationInput): Promise<ToolAcknowledgement> {
+    const sessionId = typeof input.payload.sessionId === "string" ? input.payload.sessionId : null;
+    const ackToken = typeof input.payload.ackToken === "string" ? input.payload.ackToken : null;
+    const rawInvocation = input.payload.invocation;
+
+    if (!sessionId || !ackToken || !rawInvocation) {
+      throw new RealtimeOrchestratorError("Invalid tool invocation", 400);
+    }
+
+    const entry = await this.requireSessionEntry(sessionId, ackToken);
+    const invocation = parseToolInvocationPayload(rawInvocation);
+    if (!invocation) {
+      throw new RealtimeOrchestratorError("Malformed tool invocation", 400);
+    }
+
+    invocation.sessionId = sessionId;
+    invocation.projectId = typeof input.payload.projectId === "string" ? input.payload.projectId : entry.projectId;
+
+    if (invocation.projectId) {
+      await ensureProjectMembership(invocation.projectId, input.userId, { minimumRole: "member" });
+    }
+
+    const validationErrors = validateToolInvocationPayload(invocation);
+    if (validationErrors.length > 0) {
+      throw new RealtimeOrchestratorError(validationErrors.join("; "), 400);
+    }
+
+    const acknowledgement: ToolAcknowledgement = {
+      requestId: invocation.callId,
+      status: "accepted",
+      timestamp: new Date().toISOString(),
+    };
+
+    if (invocation.name === "log_transcript_turn") {
+      const turn = parseTranscriptTurn(invocation.arguments);
+      if (!turn) {
+        throw new RealtimeOrchestratorError("Invalid transcript payload", 400);
+      }
+
+      const { flagged } = await moderateRealtimeText(turn.text);
+      if (flagged) {
+        acknowledgement.status = "rejected";
+        acknowledgement.reason = "Transcript failed moderation";
+        return acknowledgement;
+      }
+
+      const projectId = turn.projectId ?? invocation.projectId ?? entry.projectId;
+      try {
+        await persistTranscriptTurn({ ...turn, sessionId, projectId });
+      } catch (error) {
+        console.warn("Failed to persist transcript turn", error);
+        throw new RealtimeOrchestratorError("Unable to persist transcript", 500);
+      }
+
+      this.sessionCache.set(sessionId, { ...entry, projectId });
+
+      await logAuditEvent({
+        action: "transcript.turn.append",
+        userId: input.userId,
+        projectId: projectId ?? undefined,
+        targetId: turn.id,
+        details: { role: turn.role, final: turn.final },
+      });
+
+      acknowledgement.transcriptTurn = { ...turn, sessionId, projectId };
+      return acknowledgement;
+    }
+
+    if (invocation.name === "update_project_state") {
+      const args = isPlainObject(invocation.arguments) ? invocation.arguments : {};
+      const patch = isPlainObject(args.patch) ? args.patch : isPlainObject(invocation.arguments) ? invocation.arguments : null;
+      if (!patch || !isPlainObject(patch)) {
+        throw new RealtimeOrchestratorError("Invalid project state patch", 400);
+      }
+
+      const reason = typeof args.reason === "string" ? args.reason : undefined;
+
+      try {
+        await persistProjectStatePatch({
+          sessionId,
+          projectId: invocation.projectId,
+          patch,
+          reason,
+        });
+      } catch (error) {
+        console.warn("Failed to persist project state patch", error);
+        throw new RealtimeOrchestratorError("Unable to persist project state", 500);
+      }
+
+      this.sessionCache.set(sessionId, {
+        ackToken: entry.ackToken,
+        projectId: invocation.projectId ?? entry.projectId,
+        expiresAt: entry.expiresAt,
+      });
+
+      await logAuditEvent({
+        action: "project.state.patch",
+        userId: input.userId,
+        projectId: invocation.projectId ?? undefined,
+        targetId: sessionId,
+        details: { reason },
+        severity: "high",
+      });
+
+      acknowledgement.projectStatePatch = patch;
+      return acknowledgement;
+    }
+
+    acknowledgement.status = "rejected";
+    acknowledgement.reason = `Unsupported tool: ${invocation.name}`;
+    return acknowledgement;
+  }
+
+  async fetchTranscripts(input: TranscriptFetchInput): Promise<TranscriptTurnDTO[]> {
+    const entry = await this.ensureSessionEntry(input.sessionId);
+    if (entry?.projectId) {
+      await ensureProjectMembership(entry.projectId, input.userId);
+    }
+
+    try {
+      return await fetchTranscriptTurns(input.sessionId, input.limit ?? 200);
+    } catch (error) {
+      console.warn("Failed to load transcripts", error);
+      throw new RealtimeOrchestratorError("Unable to load transcripts", 500);
+    }
+  }
+
+  private async requireSessionEntry(sessionId: string, ackToken: string): Promise<SessionCacheEntry> {
+    const entry = await this.ensureSessionEntry(sessionId);
+    if (!entry || entry.ackToken !== ackToken) {
+      throw new RealtimeOrchestratorError("Unauthorized", 401);
+    }
+    return entry;
+  }
+
+  private async ensureSessionEntry(sessionId: string): Promise<SessionCacheEntry | null> {
+    if (this.sessionCache.has(sessionId)) {
+      return this.sessionCache.get(sessionId)!;
+    }
+
+    try {
+      const metadata = await fetchSessionMetadata(sessionId);
+      if (metadata?.ackToken) {
+        const entry: SessionCacheEntry = {
+          ackToken: metadata.ackToken,
+          projectId: metadata.projectId,
+          expiresAt: metadata.expiresAt,
+        };
+        this.sessionCache.set(sessionId, entry);
+        return entry;
+      }
+    } catch (error) {
+      console.warn("Failed to hydrate session cache", error);
+    }
+
+    return null;
+  }
+}
+
+let cachedService: RealtimeOrchestratorService | null = null;
+
+export function getRealtimeOrchestratorService(): RealtimeOrchestratorService {
+  if (!cachedService) {
+    cachedService = new RealtimeOrchestratorService();
+  }
+  return cachedService;
+}

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -9,7 +9,7 @@ interface RateLimitOptions {
   prefix?: string;
 }
 
-interface RateLimitResult {
+export interface RateLimitResult {
   allowed: boolean;
   remaining: number;
   limit: number;

--- a/src/lib/realtime/index.ts
+++ b/src/lib/realtime/index.ts
@@ -48,7 +48,8 @@ export type RealtimeClientEvent =
       type: "tool-acknowledged";
       invocation: ToolInvocationMessage;
       acknowledgement: ToolAcknowledgement;
-    };
+    }
+  | { type: "tool-error"; invocation: ToolInvocationMessage; error: Error };
 
 type Listener<T> = (event: T) => void;
 
@@ -168,6 +169,14 @@ function parseSessionMetadata(payload: unknown): OrchestratorSessionMetadata | n
       : [],
   };
 
+  if (payload.projectStatePatch && isPlainObject(payload.projectStatePatch)) {
+    metadata.projectStatePatch = payload.projectStatePatch as OrchestratorSessionMetadata["projectStatePatch"];
+  }
+
+  if (typeof payload.projectStatePatchReason === "string") {
+    metadata.projectStatePatchReason = payload.projectStatePatchReason;
+  }
+
   return metadata;
 }
 
@@ -195,6 +204,8 @@ export class RealtimeClient {
   private remoteAudioStream: MediaStream | null = null;
   private sessionMetadata: OrchestratorSessionMetadata | null = null;
   private pendingToolRequests = new Map<string, ToolInvocationMessage>();
+  private isRecovering = false;
+  private manualDisconnect = false;
 
   constructor(options?: RealtimeClientOptions) {
     this.tokenEndpoint = options?.tokenEndpoint ?? "/api/realtime/orchestrator";
@@ -213,9 +224,13 @@ export class RealtimeClient {
     }
 
     const { session, metadata } = await this.fetchSession();
+    this.manualDisconnect = false;
     this.session = session;
     this.sessionMetadata = metadata;
     this.events.emit({ type: "session-metadata", metadata });
+    if (metadata?.sessionId) {
+      this.requestedSessionId = metadata.sessionId;
+    }
 
     const connection = new RTCPeerConnection({
       iceServers: this.iceServers,
@@ -226,7 +241,19 @@ export class RealtimeClient {
       const state = connection.connectionState;
       this.events.emit({ type: "connection-state", state });
 
-      if (state === "failed" || state === "disconnected" || state === "closed") {
+      if ((state === "failed" || state === "disconnected") && !this.manualDisconnect) {
+        void this.recoverConnection();
+        return;
+      }
+
+      if (state === "closed") {
+        if (!this.isRecovering) {
+          this.disconnect();
+        }
+        return;
+      }
+
+      if (state === "failed" || state === "disconnected") {
         this.disconnect();
       }
     });
@@ -283,6 +310,13 @@ export class RealtimeClient {
       this.events.emit({ type: "error", error });
     });
 
+    if (this.microphoneStream) {
+      for (const track of this.microphoneStream.getTracks()) {
+        const sender = connection.addTrack(track, this.microphoneStream);
+        this.microphoneSenders.add(sender);
+      }
+    }
+
     try {
       const offer = await connection.createOffer({ offerToReceiveAudio: true });
       await connection.setLocalDescription(offer);
@@ -317,7 +351,14 @@ export class RealtimeClient {
     return { session, metadata };
   }
 
-  disconnect() {
+  disconnect(options?: {
+    preserveMetadata?: boolean;
+    preserveMicrophone?: boolean;
+    preserveAudioElement?: boolean;
+    manual?: boolean;
+  }) {
+    this.manualDisconnect = options?.manual ?? true;
+
     if (this.dataChannel) {
       try {
         this.dataChannel.close();
@@ -338,12 +379,25 @@ export class RealtimeClient {
 
     this.connection = null;
     this.session = null;
-    this.sessionMetadata = null;
-    this.pendingToolRequests.clear();
+    if (!options?.preserveMetadata) {
+      this.sessionMetadata = null;
+      this.pendingToolRequests.clear();
+    }
 
-    this.stopMicrophone();
+    if (options?.preserveMicrophone && this.microphoneStream) {
+      for (const sender of this.microphoneSenders) {
+        try {
+          this.connection?.removeTrack(sender);
+        } catch {
+          // ignore failures when the sender has already been removed
+        }
+      }
+      this.microphoneSenders.clear();
+    } else {
+      this.stopMicrophone();
+    }
 
-    if (this.remoteAudioElement) {
+    if (!options?.preserveAudioElement && this.remoteAudioElement) {
       this.remoteAudioElement.srcObject = null;
     }
 
@@ -414,6 +468,56 @@ export class RealtimeClient {
     return this.sessionMetadata;
   }
 
+  async hydrateSessionMetadata(limit = 200): Promise<OrchestratorSessionMetadata | null> {
+    const metadata = this.sessionMetadata;
+    if (!metadata?.sessionId) {
+      throw new Error("Realtime session has not been established yet");
+    }
+
+    const response = await fetch(this.tokenEndpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        action: "transcript.fetch",
+        sessionId: metadata.sessionId,
+        limit,
+      }),
+      cache: "no-store",
+    });
+
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch {
+      payload = null;
+    }
+
+    if (!response.ok) {
+      const message =
+        typeof payload === "object" && payload && "error" in payload
+          ? String((payload as { error?: unknown }).error)
+          : `Failed to hydrate session metadata: ${response.statusText}`;
+      throw new Error(message);
+    }
+
+    const transcripts = Array.isArray((payload as Record<string, unknown>)?.transcripts)
+      ? ((payload as { transcripts: unknown[] }).transcripts
+          .map(parseTranscriptTurn)
+          .filter((turn): turn is TranscriptTurnDTO => Boolean(turn)))
+      : [];
+
+    const hydrated: OrchestratorSessionMetadata = {
+      ...(this.sessionMetadata ?? metadata),
+      transcripts,
+    };
+
+    this.sessionMetadata = hydrated;
+    this.events.emit({ type: "session-metadata", metadata: hydrated });
+    return hydrated;
+  }
+
   async sendToolMessage(invocation: ToolInvocationMessage) {
     const metadata = this.sessionMetadata;
     if (!metadata?.sessionId || !metadata.ackToken) {
@@ -433,7 +537,9 @@ export class RealtimeClient {
       return acknowledgement;
     } catch (error) {
       this.pendingToolRequests.delete(invocation.callId);
-      throw error;
+      const err = error instanceof Error ? error : new Error(String(error));
+      this.events.emit({ type: "tool-error", invocation, error: err });
+      throw err;
     }
   }
 
@@ -576,7 +682,52 @@ export class RealtimeClient {
       await this.sendToolMessage(invocation);
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
+      this.events.emit({ type: "tool-error", invocation, error: err });
+    }
+  }
+
+  private async recoverConnection() {
+    if (this.isRecovering || this.manualDisconnect) {
+      return;
+    }
+
+    const metadata = this.sessionMetadata;
+    if (!metadata?.sessionId) {
+      this.disconnect();
+      return;
+    }
+
+    this.isRecovering = true;
+    try {
+      const preserveMicrophone = Boolean(this.microphoneStream);
+      this.disconnect({
+        preserveMetadata: true,
+        preserveMicrophone,
+        preserveAudioElement: true,
+        manual: false,
+      });
+
+      this.requestedSessionId = metadata.sessionId;
+      const { metadata: refreshed } = await this.connect();
+
+      if (!refreshed && this.sessionMetadata) {
+        this.sessionMetadata = {
+          ...this.sessionMetadata,
+          transcripts: metadata.transcripts ?? this.sessionMetadata.transcripts,
+        };
+        this.events.emit({ type: "session-metadata", metadata: this.sessionMetadata });
+        try {
+          await this.hydrateSessionMetadata();
+        } catch (error) {
+          const err = error instanceof Error ? error : new Error(String(error));
+          this.events.emit({ type: "error", error: err });
+        }
+      }
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
       this.events.emit({ type: "error", error: err });
+    } finally {
+      this.isRecovering = false;
     }
   }
 }

--- a/src/lib/realtime/schema.ts
+++ b/src/lib/realtime/schema.ts
@@ -53,6 +53,8 @@ export interface OrchestratorSessionMetadata {
   expiresAt?: string;
   toolSchemas: ToolSchemaDefinition[];
   transcripts?: TranscriptTurnDTO[];
+  projectStatePatch?: Partial<ScriptDoc>;
+  projectStatePatchReason?: string;
 }
 
 export const TOOL_DEFINITIONS: ToolSchemaDefinition[] = [

--- a/src/lib/transcripts.server.ts
+++ b/src/lib/transcripts.server.ts
@@ -1,3 +1,8 @@
+import { randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+import { Redis } from "@upstash/redis";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 import { getSupabaseServiceClient } from "./supabase.server";
@@ -28,23 +33,121 @@ type TranscriptRow = {
   created_at: string;
 };
 
-function getClient(): SupabaseClient | null {
-  return getSupabaseServiceClient();
-}
+const SESSION_STORE_PATH =
+  process.env.REALTIME_SESSION_STORE_PATH ?? path.join(process.cwd(), ".data", "realtime-sessions.json");
 
-export async function persistSessionMetadata(input: {
+const TRANSCRIPT_STORE_PATH =
+  process.env.REALTIME_TRANSCRIPT_STORE_PATH ??
+  path.join(process.cwd(), ".data", "realtime-transcripts.json");
+
+const DEFAULT_STORE_ENCODING: BufferEncoding = "utf8";
+
+type FileSessionRecord = {
   sessionId: string;
   projectId?: string;
   ackToken: string;
   expiresAt?: string | null;
-  rawSession?: unknown;
   orchestratorSessionId?: string | null;
-}): Promise<void> {
-  const client = getClient();
-  if (!client) {
-    return;
+  lastStatePatch?: unknown;
+  statePatchReason?: string | null;
+  updatedAt: string;
+};
+
+type FileSessionStore = Record<string, FileSessionRecord>;
+type FileTranscriptStore = Record<string, TranscriptTurnDTO[]>;
+
+let cachedRedisClient: Redis | null | undefined;
+
+function getClient(): SupabaseClient | null {
+  return getSupabaseServiceClient();
+}
+
+function getRedisClient(): Redis | null {
+  if (cachedRedisClient !== undefined) {
+    return cachedRedisClient;
   }
 
+  try {
+    cachedRedisClient = Redis.fromEnv();
+  } catch (error) {
+    console.warn("Redis client unavailable for realtime persistence", error);
+    cachedRedisClient = null;
+  }
+
+  return cachedRedisClient;
+}
+
+async function ensureFileStore<T>(filePath: string, fallback: T): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  try {
+    await fs.access(filePath);
+  } catch {
+    await fs.writeFile(filePath, JSON.stringify(fallback, null, 2), DEFAULT_STORE_ENCODING);
+  }
+}
+
+async function readFileStore<T>(filePath: string, fallback: T): Promise<T> {
+  await ensureFileStore(filePath, fallback);
+  try {
+    const raw = await fs.readFile(filePath, DEFAULT_STORE_ENCODING);
+    const parsed = JSON.parse(raw) as T;
+    return parsed;
+  } catch (error) {
+    console.warn("Failed to read realtime file store", { filePath, error });
+    return JSON.parse(JSON.stringify(fallback)) as T;
+  }
+}
+
+async function writeFileStore<T>(filePath: string, value: T): Promise<void> {
+  await ensureFileStore(filePath, value);
+  await fs.writeFile(filePath, JSON.stringify(value, null, 2), DEFAULT_STORE_ENCODING);
+}
+
+async function executeWithFallback(operations: Array<() => Promise<boolean>>): Promise<void> {
+  const errors: unknown[] = [];
+  let succeeded = false;
+
+  for (const operation of operations) {
+    try {
+      const result = await operation();
+      if (result) {
+        succeeded = true;
+      }
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+
+  if (!succeeded && errors.length) {
+    const message = errors
+      .map((error) => (error instanceof Error ? error.message : String(error)))
+      .join("; ");
+    throw new Error(`All realtime persistence backends failed: ${message}`);
+  }
+}
+
+function mapRowToMetadata(row: SessionRow): StoredSessionMetadata {
+  return {
+    sessionId: row.session_id,
+    ackToken: row.ack_token!,
+    projectId: row.project_id ?? undefined,
+    expiresAt: row.expires_at ?? undefined,
+    toolSchemas: [],
+    transcripts: [],
+  } satisfies StoredSessionMetadata;
+}
+
+async function persistSessionMetadataToSupabase(
+  client: SupabaseClient,
+  input: {
+    sessionId: string;
+    projectId?: string;
+    ackToken: string;
+    expiresAt?: string | null;
+    rawSession?: unknown;
+    orchestratorSessionId?: string | null;
+  },
+): Promise<void> {
   const now = new Date().toISOString();
   const { error } = await client.from(SESSION_TABLE).upsert(
     {
@@ -64,17 +167,64 @@ export async function persistSessionMetadata(input: {
   }
 }
 
-export interface StoredSessionMetadata extends OrchestratorSessionMetadata {}
+async function persistSessionMetadataToRedis(
+  redis: Redis,
+  input: {
+    sessionId: string;
+    projectId?: string;
+    ackToken: string;
+    expiresAt?: string | null;
+    orchestratorSessionId?: string | null;
+  },
+): Promise<void> {
+  const existingRaw = await redis.get<string>(`realtime:session:${input.sessionId}`);
+  const existing = existingRaw ? (JSON.parse(existingRaw) as FileSessionRecord) : null;
+  const record: FileSessionRecord = {
+    sessionId: input.sessionId,
+    projectId: input.projectId ?? existing?.projectId ?? undefined,
+    ackToken: input.ackToken,
+    expiresAt: input.expiresAt ?? existing?.expiresAt ?? null,
+    orchestratorSessionId: input.orchestratorSessionId ?? existing?.orchestratorSessionId ?? null,
+    lastStatePatch: existing?.lastStatePatch,
+    statePatchReason: existing?.statePatchReason ?? null,
+    updatedAt: new Date().toISOString(),
+  };
 
-export async function fetchSessionMetadata(sessionId: string): Promise<StoredSessionMetadata | null> {
-  const client = getClient();
-  if (!client) {
-    return null;
-  }
+  await redis.set(`realtime:session:${input.sessionId}`, JSON.stringify(record));
+}
 
+async function persistSessionMetadataToFile(
+  input: {
+    sessionId: string;
+    projectId?: string;
+    ackToken: string;
+    expiresAt?: string | null;
+    orchestratorSessionId?: string | null;
+  },
+): Promise<void> {
+  const store = await readFileStore<FileSessionStore>(SESSION_STORE_PATH, {});
+  const record: FileSessionRecord = {
+    sessionId: input.sessionId,
+    projectId: input.projectId ?? store[input.sessionId]?.projectId ?? undefined,
+    ackToken: input.ackToken,
+    expiresAt: input.expiresAt ?? store[input.sessionId]?.expiresAt ?? null,
+    orchestratorSessionId: input.orchestratorSessionId ?? store[input.sessionId]?.orchestratorSessionId ?? null,
+    lastStatePatch: store[input.sessionId]?.lastStatePatch,
+    statePatchReason: store[input.sessionId]?.statePatchReason ?? null,
+    updatedAt: new Date().toISOString(),
+  };
+
+  store[input.sessionId] = record;
+  await writeFileStore(SESSION_STORE_PATH, store);
+}
+
+async function fetchSessionMetadataFromSupabase(
+  client: SupabaseClient,
+  sessionId: string,
+): Promise<StoredSessionMetadata | null> {
   const { data, error } = await client
     .from(SESSION_TABLE)
-    .select("session_id, project_id, ack_token, expires_at")
+    .select("session_id, project_id, ack_token, expires_at, last_state_patch, state_patch_reason")
     .eq("session_id", sessionId)
     .maybeSingle<SessionRow>();
 
@@ -86,24 +236,83 @@ export async function fetchSessionMetadata(sessionId: string): Promise<StoredSes
     return null;
   }
 
+  const metadata = mapRowToMetadata(data);
+  if (data.last_state_patch !== undefined) {
+    metadata.projectStatePatch = data.last_state_patch ?? undefined;
+  }
+  if (data.state_patch_reason) {
+    metadata.projectStatePatchReason = data.state_patch_reason ?? undefined;
+  }
+  return metadata;
+}
+
+async function fetchSessionMetadataFromRedis(sessionId: string): Promise<StoredSessionMetadata | null> {
+  const redis = getRedisClient();
+  if (!redis) {
+    return null;
+  }
+
+  try {
+    const raw = await redis.get<string>(`realtime:session:${sessionId}`);
+    if (!raw) {
+      return null;
+    }
+
+    const record = JSON.parse(raw) as FileSessionRecord;
+    if (!record.ackToken) {
+      return null;
+    }
+
+    const metadata: StoredSessionMetadata = {
+      sessionId: record.sessionId,
+      ackToken: record.ackToken,
+      projectId: record.projectId,
+      expiresAt: record.expiresAt ?? undefined,
+      toolSchemas: [],
+      transcripts: [],
+    };
+
+    if (record.lastStatePatch !== undefined) {
+      metadata.projectStatePatch = record.lastStatePatch;
+    }
+    if (record.statePatchReason) {
+      metadata.projectStatePatchReason = record.statePatchReason ?? undefined;
+    }
+
+    return metadata;
+  } catch (error) {
+    console.warn("Failed to load realtime session metadata from Redis", error);
+    return null;
+  }
+}
+
+async function fetchSessionMetadataFromFile(sessionId: string): Promise<StoredSessionMetadata | null> {
+  const store = await readFileStore<FileSessionStore>(SESSION_STORE_PATH, {});
+  const record = store[sessionId];
+  if (!record?.ackToken) {
+    return null;
+  }
+
   const metadata: StoredSessionMetadata = {
-    sessionId: data.session_id,
-    ackToken: data.ack_token,
-    projectId: data.project_id ?? undefined,
-    expiresAt: data.expires_at ?? undefined,
+    sessionId: record.sessionId,
+    ackToken: record.ackToken,
+    projectId: record.projectId,
+    expiresAt: record.expiresAt ?? undefined,
     toolSchemas: [],
     transcripts: [],
   };
 
+  if (record.lastStatePatch !== undefined) {
+    metadata.projectStatePatch = record.lastStatePatch;
+  }
+  if (record.statePatchReason) {
+    metadata.projectStatePatchReason = record.statePatchReason ?? undefined;
+  }
+
   return metadata;
 }
 
-export async function persistTranscriptTurn(turn: TranscriptTurnDTO & { sessionId: string }): Promise<void> {
-  const client = getClient();
-  if (!client) {
-    return;
-  }
-
+async function persistTranscriptTurnToSupabase(client: SupabaseClient, turn: TranscriptTurnDTO & { sessionId: string }) {
   const { error } = await client.from(TRANSCRIPT_TABLE).upsert(
     {
       id: turn.id,
@@ -122,15 +331,32 @@ export async function persistTranscriptTurn(turn: TranscriptTurnDTO & { sessionI
   }
 }
 
-export async function fetchTranscriptTurns(
-  sessionId: string,
-  limit = 50,
-): Promise<TranscriptTurnDTO[]> {
-  const client = getClient();
-  if (!client) {
-    return [];
-  }
+async function persistTranscriptTurnToRedis(redis: Redis, turn: TranscriptTurnDTO & { sessionId: string }) {
+  await redis.hset(`realtime:transcripts:${turn.sessionId}`, {
+    [turn.id]: JSON.stringify(turn),
+  });
+}
 
+async function persistTranscriptTurnToFile(turn: TranscriptTurnDTO & { sessionId: string }) {
+  const store = await readFileStore<FileTranscriptStore>(TRANSCRIPT_STORE_PATH, {});
+  const entries = store[turn.sessionId] ?? [];
+  const index = entries.findIndex((entry) => entry.id === turn.id);
+  if (index >= 0) {
+    entries[index] = turn;
+  } else {
+    entries.push(turn);
+  }
+  store[turn.sessionId] = entries
+    .slice()
+    .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+  await writeFileStore(TRANSCRIPT_STORE_PATH, store);
+}
+
+async function fetchTranscriptTurnsFromSupabase(
+  client: SupabaseClient,
+  sessionId: string,
+  limit: number,
+): Promise<TranscriptTurnDTO[]> {
   const { data, error } = await client
     .from(TRANSCRIPT_TABLE)
     .select("id, session_id, project_id, role, content, final, created_at")
@@ -154,17 +380,46 @@ export async function fetchTranscriptTurns(
   }));
 }
 
-export async function persistProjectStatePatch(input: {
-  sessionId: string;
-  projectId?: string;
-  patch: unknown;
-  reason?: string;
-}): Promise<void> {
-  const client = getClient();
-  if (!client) {
-    return;
+async function fetchTranscriptTurnsFromRedis(sessionId: string): Promise<TranscriptTurnDTO[] | null> {
+  const redis = getRedisClient();
+  if (!redis) {
+    return null;
   }
 
+  try {
+    const values = await redis.hvals<string>(`realtime:transcripts:${sessionId}`);
+    if (!values?.length) {
+      return [];
+    }
+
+    return values
+      .map((value) => {
+        try {
+          return JSON.parse(value) as TranscriptTurnDTO & { sessionId?: string };
+        } catch {
+          return null;
+        }
+      })
+      .filter((turn): turn is TranscriptTurnDTO => Boolean(turn))
+      .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+  } catch (error) {
+    console.warn("Failed to load transcript turns from Redis", error);
+    return null;
+  }
+}
+
+async function fetchTranscriptTurnsFromFile(sessionId: string): Promise<TranscriptTurnDTO[]> {
+  const store = await readFileStore<FileTranscriptStore>(TRANSCRIPT_STORE_PATH, {});
+  return (store[sessionId] ?? []).map((entry) => ({
+    ...entry,
+    sessionId,
+  }));
+}
+
+async function persistProjectStatePatchToSupabase(
+  client: SupabaseClient,
+  input: { sessionId: string; projectId?: string; patch: unknown; reason?: string },
+) {
   const now = new Date().toISOString();
   const { error } = await client.from(SESSION_TABLE).upsert(
     {
@@ -180,4 +435,175 @@ export async function persistProjectStatePatch(input: {
   if (error) {
     throw new Error(error.message ?? "Failed to persist project state patch");
   }
+}
+
+async function persistProjectStatePatchToRedis(
+  redis: Redis,
+  input: { sessionId: string; projectId?: string; patch: unknown; reason?: string },
+) {
+  const raw = await redis.get<string>(`realtime:session:${input.sessionId}`);
+  const existing = raw ? (JSON.parse(raw) as FileSessionRecord) : null;
+  const record: FileSessionRecord = {
+    sessionId: input.sessionId,
+    projectId: input.projectId ?? existing?.projectId ?? undefined,
+    ackToken: existing?.ackToken ?? randomUUID(),
+    expiresAt: existing?.expiresAt ?? null,
+    orchestratorSessionId: existing?.orchestratorSessionId ?? null,
+    lastStatePatch: input.patch,
+    statePatchReason: input.reason ?? null,
+    updatedAt: new Date().toISOString(),
+  };
+
+  await redis.set(`realtime:session:${input.sessionId}`, JSON.stringify(record));
+}
+
+async function persistProjectStatePatchToFile(input: {
+  sessionId: string;
+  projectId?: string;
+  patch: unknown;
+  reason?: string;
+}) {
+  const store = await readFileStore<FileSessionStore>(SESSION_STORE_PATH, {});
+  const record = store[input.sessionId] ?? {
+    sessionId: input.sessionId,
+    ackToken: randomUUID(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  record.projectId = input.projectId ?? record.projectId;
+  record.lastStatePatch = input.patch;
+  record.statePatchReason = input.reason ?? null;
+  record.updatedAt = new Date().toISOString();
+
+  store[input.sessionId] = record;
+  await writeFileStore(SESSION_STORE_PATH, store);
+}
+
+export async function persistSessionMetadata(input: {
+  sessionId: string;
+  projectId?: string;
+  ackToken: string;
+  expiresAt?: string | null;
+  rawSession?: unknown;
+  orchestratorSessionId?: string | null;
+}): Promise<void> {
+  const client = getClient();
+  const redis = getRedisClient();
+
+  await executeWithFallback([
+    async () => {
+      if (!client) return false;
+      await persistSessionMetadataToSupabase(client, input);
+      return true;
+    },
+    async () => {
+      if (!redis) return false;
+      await persistSessionMetadataToRedis(redis, input);
+      return true;
+    },
+    async () => {
+      await persistSessionMetadataToFile(input);
+      return true;
+    },
+  ]);
+}
+
+export interface StoredSessionMetadata extends OrchestratorSessionMetadata {}
+
+export async function fetchSessionMetadata(sessionId: string): Promise<StoredSessionMetadata | null> {
+  const client = getClient();
+  const redis = getRedisClient();
+
+  if (client) {
+    try {
+      const metadata = await fetchSessionMetadataFromSupabase(client, sessionId);
+      if (metadata) {
+        return metadata;
+      }
+    } catch (error) {
+      console.warn("Failed to fetch realtime session metadata from Supabase", error);
+    }
+  }
+
+  const redisMetadata = await fetchSessionMetadataFromRedis(sessionId);
+  if (redisMetadata) {
+    return redisMetadata;
+  }
+
+  return fetchSessionMetadataFromFile(sessionId);
+}
+
+export async function persistTranscriptTurn(turn: TranscriptTurnDTO & { sessionId: string }): Promise<void> {
+  const client = getClient();
+  const redis = getRedisClient();
+
+  await executeWithFallback([
+    async () => {
+      if (!client) return false;
+      await persistTranscriptTurnToSupabase(client, turn);
+      return true;
+    },
+    async () => {
+      if (!redis) return false;
+      await persistTranscriptTurnToRedis(redis, turn);
+      return true;
+    },
+    async () => {
+      await persistTranscriptTurnToFile(turn);
+      return true;
+    },
+  ]);
+}
+
+export async function fetchTranscriptTurns(
+  sessionId: string,
+  limit = 50,
+): Promise<TranscriptTurnDTO[]> {
+  const client = getClient();
+
+  if (client) {
+    try {
+      const turns = await fetchTranscriptTurnsFromSupabase(client, sessionId, limit);
+      if (turns.length) {
+        return turns;
+      }
+    } catch (error) {
+      console.warn("Failed to load transcript turns from Supabase", error);
+    }
+  }
+
+  const redisTurns = await fetchTranscriptTurnsFromRedis(sessionId);
+  if (redisTurns?.length) {
+    return redisTurns.slice(0, limit);
+  }
+
+  const fileTurns = await fetchTranscriptTurnsFromFile(sessionId);
+  return fileTurns.slice(0, limit);
+}
+
+export async function persistProjectStatePatch(input: {
+  sessionId: string;
+  projectId?: string;
+  patch: unknown;
+  reason?: string;
+}): Promise<void> {
+  const client = getClient();
+  const redis = getRedisClient();
+
+  await executeWithFallback([
+    async () => {
+      if (!client) return false;
+      await persistProjectStatePatchToSupabase(client, input);
+      return true;
+    },
+    async () => {
+      if (!redis) return false;
+      await persistProjectStatePatchToRedis(redis, input);
+      return true;
+    },
+    async () => {
+      await persistProjectStatePatchToFile(input);
+      return true;
+    },
+  ]);
 }


### PR DESCRIPTION
## Summary
- add a server-side orchestrator service with shared rate limit/moderation middleware and audit logging
- persist session metadata, transcript turns, and project state patches with Supabase primary storage and Redis/file fallbacks
- extend the realtime client and studio UI to surface tool errors, recover dropped sessions, and hydrate session metadata

## Testing
- npm run test:unit *(fails: vitest binary missing because dependencies cannot be installed in the sandbox)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69143b4647dc8322b7b58842f7b43dd1)