### PR TITLE
Add signed storage download hooks

### DIFF
--- a/src/app/api/assets/download/route.test.ts
+++ b/src/app/api/assets/download/route.test.ts
@@ -1,0 +1,76 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GET } from "./route";
+
+const assetModule = vi.hoisted(() => ({
+  getReferenceAsset: vi.fn(),
+}));
+
+const storageModule = vi.hoisted(() => ({
+  getStorageProvider: vi.fn(),
+}));
+
+const authModule = vi.hoisted(() => {
+  class UnauthorizedError extends Error {}
+  return {
+    requireServerAuthSession: vi.fn().mockResolvedValue({ user: { id: "user-1" } }),
+    UnauthorizedError,
+  };
+});
+
+const authzModule = vi.hoisted(() => {
+  class ProjectAuthorizationError extends Error {}
+  return {
+    ensureProjectMembership: vi.fn(),
+    ProjectAuthorizationError,
+  };
+});
+
+vi.mock("@/lib/assets", () => assetModule);
+vi.mock("@/lib/storage", () => storageModule);
+vi.mock("@/lib/auth/server", () => authModule);
+vi.mock("@/lib/authz/projects.server", () => authzModule);
+
+const mockGetReferenceAsset = assetModule.getReferenceAsset;
+const mockGetStorageProvider = storageModule.getStorageProvider;
+const mockRequireServerAuthSession = authModule.requireServerAuthSession;
+const mockEnsureProjectMembership = authzModule.ensureProjectMembership;
+
+describe("/api/assets/download", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireServerAuthSession.mockResolvedValue({ user: { id: "user-1" } });
+    mockEnsureProjectMembership.mockResolvedValue(undefined);
+  });
+
+  it("returns a signed download URL", async () => {
+    mockGetReferenceAsset.mockResolvedValueOnce({
+      id: "asset-1",
+      projectId: "p1",
+      contentType: "image/png",
+      name: "Poster",
+    });
+    mockGetStorageProvider.mockReturnValueOnce({
+      createSignedDownload: vi
+        .fn()
+        .mockResolvedValue({ url: "https://signed", expiresAt: "2024-01-01T00:00:00.000Z" }),
+      createSignedUpload: vi.fn(),
+    });
+
+    const request = new NextRequest("http://localhost/api/assets/download?assetId=asset-1");
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      download: { url: "https://signed", expiresAt: "2024-01-01T00:00:00.000Z" },
+    });
+  });
+
+  it("returns 404 when the asset does not exist", async () => {
+    mockGetReferenceAsset.mockResolvedValueOnce(null);
+    const request = new NextRequest("http://localhost/api/assets/download?assetId=missing");
+    const response = await GET(request);
+    expect(response.status).toBe(404);
+  });
+});

--- a/src/app/api/assets/download/route.ts
+++ b/src/app/api/assets/download/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { requireServerAuthSession, UnauthorizedError } from "@/lib/auth/server";
+import {
+  ensureProjectMembership,
+  ProjectAuthorizationError,
+} from "@/lib/authz/projects.server";
+import { getReferenceAsset } from "@/lib/assets";
+import { getStorageProvider } from "@/lib/storage";
+
+export const runtime = "nodejs";
+
+export async function GET(request: NextRequest) {
+  const assetId = request.nextUrl.searchParams.get("assetId");
+  if (!assetId) {
+    return NextResponse.json({ error: "Missing assetId" }, { status: 400 });
+  }
+
+  try {
+    const { user } = await requireServerAuthSession();
+    const asset = await getReferenceAsset(assetId);
+    if (!asset) {
+      return NextResponse.json({ error: "Asset not found" }, { status: 404 });
+    }
+
+    if (asset.projectId) {
+      await ensureProjectMembership(asset.projectId, user.id);
+    }
+
+    const storage = getStorageProvider();
+    const download = await storage.createSignedDownload({
+      assetId: asset.id,
+      contentType: asset.contentType,
+      projectId: asset.projectId ?? undefined,
+      fileName: asset.name,
+    });
+
+    return NextResponse.json({ download });
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (error instanceof ProjectAuthorizationError) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    console.error("Failed to create download URL", error);
+    return NextResponse.json({ error: "Unable to create download link" }, { status: 500 });
+  }
+}

--- a/src/app/api/assets/route.test.ts
+++ b/src/app/api/assets/route.test.ts
@@ -17,8 +17,26 @@ const storageModule = vi.hoisted(() => ({
   getStorageProvider: vi.fn(),
 }));
 
+const authModule = vi.hoisted(() => {
+  class UnauthorizedError extends Error {}
+  return {
+    requireServerAuthSession: vi.fn().mockResolvedValue({ user: { id: "user-1" } }),
+    UnauthorizedError,
+  };
+});
+
+const authzModule = vi.hoisted(() => {
+  class ProjectAuthorizationError extends Error {}
+  return {
+    ensureProjectMembership: vi.fn(),
+    ProjectAuthorizationError,
+  };
+});
+
 vi.mock("@/lib/assets", () => assetModule);
 vi.mock("@/lib/storage", () => storageModule);
+vi.mock("@/lib/auth/server", () => authModule);
+vi.mock("@/lib/authz/projects.server", () => authzModule);
 
 const mockListReferenceAssets = assetModule.listReferenceAssets;
 const mockGetReferenceAsset = assetModule.getReferenceAsset;
@@ -27,6 +45,8 @@ const mockRecordAssetBinary = assetModule.recordAssetBinary;
 const mockUpdateReferenceAsset = assetModule.updateReferenceAsset;
 const mockUpdateReferenceAssetLifecycle = assetModule.updateReferenceAssetLifecycle;
 const mockGetStorageProvider = storageModule.getStorageProvider;
+const mockRequireServerAuthSession = authModule.requireServerAuthSession;
+const mockEnsureProjectMembership = authzModule.ensureProjectMembership;
 
 const observabilityModule = vi.hoisted(() => ({
   recordApiRequest: vi.fn(),
@@ -44,6 +64,8 @@ const mockCaptureApiException = observabilityModule.captureApiException;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockRequireServerAuthSession.mockResolvedValue({ user: { id: "user-1" } });
+  mockEnsureProjectMembership.mockResolvedValue(undefined);
 });
 
 describe("/api/assets", () => {
@@ -78,9 +100,17 @@ describe("/api/assets", () => {
   });
 
   it("creates a new asset and returns upload info", async () => {
-    mockCreateReferenceAsset.mockResolvedValueOnce({ id: "asset-1", projectId: "p1" });
+    mockCreateReferenceAsset.mockResolvedValueOnce({ id: "asset-1", projectId: "p1", url: "" });
+    mockUpdateReferenceAsset.mockResolvedValueOnce({
+      id: "asset-1",
+      projectId: "p1",
+      url: "https://storage/asset-1",
+    });
     mockGetStorageProvider.mockReturnValueOnce({
-      createSignedUpload: vi.fn().mockResolvedValue({ uploadUrl: "signed" }),
+      createSignedUpload: vi
+        .fn()
+        .mockResolvedValue({ uploadUrl: "signed", assetUrl: "https://storage/asset-1" }),
+      createSignedDownload: vi.fn(),
     });
 
     const request = new NextRequest("http://localhost/api/assets", {
@@ -92,8 +122,11 @@ describe("/api/assets", () => {
     const response = await POST(request);
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
-      asset: { id: "asset-1", projectId: "p1" },
+      asset: { id: "asset-1", projectId: "p1", url: "https://storage/asset-1" },
       upload: { uploadUrl: "signed" },
+    });
+    expect(mockUpdateReferenceAsset).toHaveBeenCalledWith("asset-1", {
+      url: "https://storage/asset-1",
     });
   });
 

--- a/src/app/api/assets/route.ts
+++ b/src/app/api/assets/route.ts
@@ -138,8 +138,20 @@ export async function POST(request: NextRequest) {
       projectId: asset.projectId ?? undefined,
     });
 
+    let responseAsset = asset;
+    if (!asset.url && signedUpload.assetUrl) {
+      try {
+        const updated = await updateReferenceAsset(asset.id, { url: signedUpload.assetUrl });
+        if (updated) {
+          responseAsset = updated;
+        }
+      } catch (updateError) {
+        console.warn("Failed to persist storage URL for asset", updateError);
+      }
+    }
+
     return NextResponse.json({
-      asset: serializeReferenceAsset(asset),
+      asset: serializeReferenceAsset(responseAsset),
       upload: signedUpload,
     });
   } catch (error) {

--- a/src/lib/db/assets.ts
+++ b/src/lib/db/assets.ts
@@ -166,21 +166,53 @@ export async function modifyReferenceAsset(
   }
 
   const supabase = getSupabaseClient();
-  const payload: Partial<ReferenceAssetRow> = {
-    name: updates.name,
-    description: updates.description ?? null,
-    url: updates.url,
-    thumbnail_url: updates.thumbnailUrl ?? null,
-    preview_color: updates.previewColor ?? null,
-    tags: updates.tags,
-    status: updates.status,
-    scan_status: updates.scanStatus,
-    transcode_status: updates.transcodeStatus,
-    processing_progress: updates.processingProgress ?? null,
-    failure_code: updates.failureCode ?? null,
-    failure_message: updates.failureMessage ?? null,
-    attribution: updates.attribution ?? null,
-  };
+  const payload: Partial<ReferenceAssetRow> = {};
+
+  if (Object.prototype.hasOwnProperty.call(updates, "name")) {
+    payload.name = updates.name ?? "";
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, "description")) {
+    payload.description = updates.description ?? null;
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, "url")) {
+    payload.url = updates.url ?? "";
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, "thumbnailUrl")) {
+    payload.thumbnail_url = updates.thumbnailUrl ?? null;
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, "previewColor")) {
+    payload.preview_color = updates.previewColor ?? null;
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, "tags")) {
+    payload.tags = updates.tags ?? [];
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, "status")) {
+    payload.status = updates.status as ReferenceAssetRow["status"];
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, "scanStatus")) {
+    payload.scan_status = updates.scanStatus as ReferenceAssetRow["scan_status"];
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, "transcodeStatus")) {
+    payload.transcode_status = updates.transcodeStatus as ReferenceAssetRow["transcode_status"];
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, "processingProgress")) {
+    payload.processing_progress = updates.processingProgress ?? null;
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, "failureCode")) {
+    payload.failure_code = updates.failureCode ?? null;
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, "failureMessage")) {
+    payload.failure_message = updates.failureMessage ?? null;
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, "attribution")) {
+    payload.attribution = updates.attribution ?? null;
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, "contentType")) {
+    payload.content_type = updates.contentType ?? "application/octet-stream";
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, "size")) {
+    payload.size = updates.size ?? 0;
+  }
 
   const { data, error } = await supabase
     .from<ReferenceAssetRow>("reference_assets")

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,4 +1,4 @@
-import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import { GetObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 import { getSupabaseClient } from "@/lib/db/client";
@@ -30,6 +30,12 @@ export interface SignedUpload {
   expiresAt: string;
 }
 
+export interface SignedDownload {
+  url: string;
+  headers?: Record<string, string>;
+  expiresAt: string;
+}
+
 export interface StorageProvider {
   createSignedUpload(input: {
     assetId: string;
@@ -37,6 +43,13 @@ export interface StorageProvider {
     size: number;
     projectId?: string | null;
   }): Promise<SignedUpload>;
+
+  createSignedDownload(input: {
+    assetId: string;
+    contentType: string;
+    projectId?: string | null;
+    fileName?: string;
+  }): Promise<SignedDownload>;
 }
 
 function normaliseContentType(value: string): string {
@@ -160,6 +173,19 @@ class LocalStorageProvider implements StorageProvider {
       expiresAt: expires.toISOString(),
     };
   }
+
+  async createSignedDownload({ assetId }: {
+    assetId: string;
+    contentType: string;
+    projectId?: string | null;
+    fileName?: string;
+  }): Promise<SignedDownload> {
+    const expiresAt = new Date(Date.now() + STORAGE_SIGNED_URL_TTL_SECONDS * 1000).toISOString();
+    return {
+      url: `/api/assets?assetId=${assetId}`,
+      expiresAt,
+    };
+  }
 }
 
 class SupabaseStorageProvider implements StorageProvider {
@@ -217,6 +243,51 @@ class SupabaseStorageProvider implements StorageProvider {
       },
       assetUrl: baseUrl ?? fallbackAssetUrl,
       expiresAt,
+    };
+  }
+
+  async createSignedDownload({
+    assetId,
+    contentType,
+    projectId,
+    fileName,
+  }: {
+    assetId: string;
+    contentType: string;
+    projectId?: string | null;
+    fileName?: string;
+  }): Promise<SignedDownload> {
+    if (!isSupabaseConfigured()) {
+      throw new Error("Supabase storage is not configured");
+    }
+
+    const client = getSupabaseClient();
+    const path = buildStoragePath({
+      assetId,
+      contentType,
+      projectId,
+      prefix: SUPABASE_STORAGE_FOLDER,
+    });
+
+    const { data, error } = await client.storage
+      .from(SUPABASE_STORAGE_BUCKET)
+      .createSignedUrl(path, STORAGE_SIGNED_URL_TTL_SECONDS, {
+        download: fileName,
+      });
+
+    if (error || !data) {
+      console.error("Failed to create Supabase signed download", error);
+      throw error ?? new Error("Unable to create signed download");
+    }
+
+    const supabaseBaseUrl = SUPABASE_URL?.replace(/\/$/, "");
+    const absoluteUrl = data.signedUrl.startsWith("http")
+      ? data.signedUrl
+      : `${supabaseBaseUrl ?? ""}${data.signedUrl.startsWith("/") ? "" : "/"}${data.signedUrl}`;
+
+    return {
+      url: absoluteUrl,
+      expiresAt: new Date(Date.now() + STORAGE_SIGNED_URL_TTL_SECONDS * 1000).toISOString(),
     };
   }
 }
@@ -292,6 +363,44 @@ class S3StorageProvider implements StorageProvider {
       },
       assetUrl,
       expiresAt,
+    };
+  }
+
+  async createSignedDownload({
+    assetId,
+    contentType,
+    projectId,
+    fileName,
+  }: {
+    assetId: string;
+    contentType: string;
+    projectId?: string | null;
+    fileName?: string;
+  }): Promise<SignedDownload> {
+    if (!S3_BUCKET || !S3_REGION) {
+      throw new Error("S3 storage is not configured");
+    }
+
+    const key = buildStoragePath({
+      assetId,
+      contentType,
+      projectId,
+      prefix: S3_PREFIX,
+    });
+
+    const command = new GetObjectCommand({
+      Bucket: S3_BUCKET,
+      Key: key,
+      ResponseContentDisposition: fileName ? `attachment; filename="${encodeURIComponent(fileName)}"` : undefined,
+    });
+
+    const url = await getSignedUrl(this.client, command, {
+      expiresIn: STORAGE_SIGNED_URL_TTL_SECONDS,
+    });
+
+    return {
+      url,
+      expiresAt: new Date(Date.now() + STORAGE_SIGNED_URL_TTL_SECONDS * 1000).toISOString(),
     };
   }
 }


### PR DESCRIPTION
## Summary
- extend the storage provider so Supabase and S3 issue both upload and download presigned URLs with shared validation
- persist remote storage URLs inside the asset records and expose a new /api/assets/download endpoint for the studio to fetch signed download links
- tighten Supabase update logic and expand API tests around uploads plus add new download endpoint tests

## Testing
- ⚠️ `npm run test:unit` *(fails: vitest is unavailable because npm install cannot reach the registry in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691646e912348322a33f4adc05605e8d)