### PR TITLE
Add Supabase auth session controls and server sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The application now auto-detects a Supabase backend for durable storage. To enab
    SUPABASE_URL="https://your-project-ref.supabase.co"
    SUPABASE_SERVICE_ROLE_KEY="your-service-role-key" # or set SUPABASE_KEY to use an anon key with permissive RLS
    SUPABASE_ACCESS_REQUESTS_TABLE="access_requests" # optional override
+   NEXT_PUBLIC_SUPABASE_URL="$SUPABASE_URL" # exposes the URL to the browser for auth flows
+   NEXT_PUBLIC_SUPABASE_ANON_KEY="your-anon-key" # used by the client to request magic links / OAuth
    ```
 
 3. Restart the dev server. The `/api/request-access` endpoint will now read/write access requests in Supabase while preserving the JSON-file fallback when credentials are absent.

--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -1,0 +1,75 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+import { ACCESS_TOKEN_COOKIE, REFRESH_TOKEN_COOKIE } from "@/lib/auth/server";
+import { logAuditEvent } from "@/lib/auditLog";
+import { getSupabaseServiceClient } from "@/lib/supabase.server";
+
+export const runtime = "nodejs";
+
+interface SessionPayload {
+  accessToken?: string;
+  refreshToken?: string;
+}
+
+function setAuthCookie(name: string, value: string, maxAgeSeconds: number) {
+  const cookieStore = cookies();
+  cookieStore.set(name, value, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: maxAgeSeconds,
+  });
+}
+
+export async function POST(request: Request) {
+  let payload: SessionPayload;
+  try {
+    payload = (await request.json()) as SessionPayload;
+  } catch {
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+  }
+
+  const accessToken = payload.accessToken?.trim();
+  if (!accessToken) {
+    return NextResponse.json({ error: "accessToken is required" }, { status: 400 });
+  }
+
+  const supabase = getSupabaseServiceClient();
+  if (!supabase) {
+    return NextResponse.json({ error: "Supabase is not configured" }, { status: 503 });
+  }
+
+  try {
+    const { data, error } = await supabase.auth.getUser(accessToken);
+    if (error || !data?.user) {
+      return NextResponse.json({ error: "Invalid access token" }, { status: 401 });
+    }
+
+    setAuthCookie(ACCESS_TOKEN_COOKIE, accessToken, 60 * 60);
+
+    if (payload.refreshToken?.trim()) {
+      setAuthCookie(REFRESH_TOKEN_COOKIE, payload.refreshToken.trim(), 60 * 60 * 24 * 30);
+    }
+
+    await logAuditEvent({
+      action: "auth.session.sync",
+      userId: data.user.id,
+      details: { source: "browser" },
+    });
+
+    return NextResponse.json({ ok: true, user: { id: data.user.id } });
+  } catch (error) {
+    console.error("Failed to sync session", error);
+    return NextResponse.json({ error: "Unable to sync session" }, { status: 500 });
+  }
+}
+
+export async function DELETE() {
+  const cookieStore = cookies();
+  cookieStore.delete(ACCESS_TOKEN_COOKIE);
+  cookieStore.delete(REFRESH_TOKEN_COOKIE);
+
+  return NextResponse.json({ ok: true }, { status: 200 });
+}

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+import { getSupabaseBrowserClient, syncSessionCookie } from "@/lib/auth/client";
+
+export default function AuthCallbackPage() {
+  const router = useRouter();
+  const [status, setStatus] = useState<string>("Verifying your session…");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const supabase = getSupabaseBrowserClient();
+    if (!supabase) {
+      setError("Supabase authentication is not configured.");
+      setStatus("Unable to complete sign-in");
+      return;
+    }
+
+    let cancelled = false;
+
+    async function exchangeSession() {
+      try {
+        const { data, error: exchangeError } = await supabase.auth.exchangeCodeForSession(
+          window.location.href,
+        );
+        if (cancelled) {
+          return;
+        }
+
+        if (exchangeError) {
+          setError(exchangeError.message ?? "Unable to verify session");
+          setStatus("Verification failed");
+          return;
+        }
+
+        await syncSessionCookie(data.session ?? null);
+        setStatus("Session established. Redirecting to the studio…");
+        setTimeout(() => {
+          router.replace("/studio");
+        }, 1200);
+      } catch (err) {
+        if (cancelled) {
+          return;
+        }
+        setError(err instanceof Error ? err.message : "Unable to verify session");
+        setStatus("Verification failed");
+      }
+    }
+
+    void exchangeSession();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [router]);
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-zinc-950 px-6 text-center text-white">
+      <div className="max-w-md space-y-3">
+        <p className="text-xs uppercase tracking-[0.4em] text-zinc-500">Auth callback</p>
+        <h1 className="text-2xl font-semibold text-white">{status}</h1>
+        {error ? <p className="text-sm text-rose-300">{error}</p> : null}
+        {!error ? (
+          <p className="text-sm text-zinc-400">
+            You’ll be routed back to the studio the moment we finish negotiating your credentials.
+          </p>
+        ) : (
+          <p className="text-sm text-zinc-400">
+            Use the session controls to retry or head back to the marketing site.
+          </p>
+        )}
+      </div>
+      <Link
+        href="/"
+        className="rounded-full border border-white/20 px-6 py-2 text-sm font-semibold text-white transition hover:border-white/40"
+      >
+        Return home
+      </Link>
+    </main>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
+
+import { SessionControls } from "@/components/SessionControls";
+
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -15,7 +18,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <SessionControls />
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/components/SessionControls.tsx
+++ b/src/components/SessionControls.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import type { FormEvent } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import type { Session } from "@supabase/supabase-js";
+
+import {
+  getSupabaseBrowserClient,
+  isBrowserSupabaseConfigured,
+  syncSessionCookie,
+} from "@/lib/auth/client";
+
+function formatUserLabel(session: Session): string {
+  return (
+    session.user.email ||
+    (typeof session.user.user_metadata?.full_name === "string"
+      ? session.user.user_metadata.full_name
+      : null) ||
+    session.user.id
+  );
+}
+
+export function SessionControls() {
+  const router = useRouter();
+  const [session, setSession] = useState<Session | null>(null);
+  const [email, setEmail] = useState("");
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isReady, setIsReady] = useState(false);
+
+  const supabase = useMemo(() => getSupabaseBrowserClient(), []);
+  const supabaseEnabled = isBrowserSupabaseConfigured();
+
+  useEffect(() => {
+    if (!supabaseEnabled || !supabase) {
+      setIsReady(true);
+      return;
+    }
+
+    let isMounted = true;
+
+    void supabase.auth.getSession().then(async ({ data }) => {
+      if (!isMounted) {
+        return;
+      }
+      setSession(data?.session ?? null);
+      setIsReady(true);
+      await syncSessionCookie(data?.session ?? null);
+    });
+
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, nextSession) => {
+      setSession(nextSession);
+      void syncSessionCookie(nextSession);
+      if (!nextSession) {
+        router.push("/");
+      }
+    });
+
+    return () => {
+      isMounted = false;
+      listener.subscription.unsubscribe();
+    };
+  }, [router, supabase, supabaseEnabled]);
+
+  const handleMagicLink = useCallback(
+    async (event: FormEvent) => {
+      event.preventDefault();
+      if (!supabase) {
+        return;
+      }
+      setIsSubmitting(true);
+      setError(null);
+      setStatusMessage(null);
+
+      try {
+        const emailValue = email.trim();
+        if (!emailValue) {
+          setError("Enter your email address to receive a link.");
+          return;
+        }
+
+        const redirectTo = `${window.location.origin}/auth/callback`;
+        const { error: authError } = await supabase.auth.signInWithOtp({
+          email: emailValue,
+          options: { emailRedirectTo: redirectTo },
+        });
+
+        if (authError) {
+          setError(authError.message ?? "Unable to send magic link");
+          return;
+        }
+
+        setStatusMessage("Check your inbox for the magic link.");
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Unable to send magic link");
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [email, supabase],
+  );
+
+  const handleOAuth = useCallback(
+    async (provider: "google" | "github") => {
+      if (!supabase) {
+        return;
+      }
+      setError(null);
+      const redirectTo = `${window.location.origin}/auth/callback`;
+      const { error: authError } = await supabase.auth.signInWithOAuth({
+        provider,
+        options: { redirectTo },
+      });
+
+      if (authError) {
+        setError(authError.message ?? "Unable to start OAuth flow");
+      }
+    },
+    [supabase],
+  );
+
+  const handleSignOut = useCallback(async () => {
+    if (!supabase) {
+      await syncSessionCookie(null);
+      router.push("/");
+      return;
+    }
+
+    try {
+      await supabase.auth.signOut();
+      await syncSessionCookie(null);
+      router.push("/");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to log out");
+    }
+  }, [router, supabase]);
+
+  if (!supabaseEnabled) {
+    return null;
+  }
+
+  return (
+    <div className="pointer-events-auto fixed right-5 top-5 z-50 max-w-sm text-sm">
+      <div className="rounded-2xl border border-white/10 bg-zinc-900/80 p-4 text-white shadow-2xl backdrop-blur">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="text-xs uppercase tracking-[0.3em] text-zinc-400">Session</p>
+            <p className="text-base font-semibold text-white">
+              {session ? "Active" : isReady ? "Offline" : "Checking"}
+            </p>
+          </div>
+          <Link
+            href={session ? "/studio" : "/"}
+            className="rounded-full border border-white/20 px-4 py-1.5 text-xs font-semibold text-white transition hover:border-white/50"
+          >
+            {session ? "Studio" : "Home"}
+          </Link>
+        </div>
+
+        {session ? (
+          <div className="mt-3 space-y-3">
+            <p className="text-sm text-zinc-300">
+              Signed in as <span className="font-medium text-white">{formatUserLabel(session)}</span>
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => router.push("/studio")}
+                className="inline-flex flex-1 items-center justify-center rounded-full border border-white/20 bg-white/10 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-white/20"
+              >
+                Resume session
+              </button>
+              <button
+                type="button"
+                onClick={handleSignOut}
+                className="inline-flex flex-1 items-center justify-center rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-semibold text-white transition hover:border-white/40"
+              >
+                Log out
+              </button>
+            </div>
+          </div>
+        ) : (
+          <form className="mt-3 space-y-3" onSubmit={handleMagicLink}>
+            <label className="text-xs font-medium uppercase tracking-[0.3em] text-zinc-400">
+              Magic link
+            </label>
+            <input
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              className="w-full rounded-full border border-white/15 bg-white/5 px-4 py-2 text-sm text-white placeholder:text-zinc-500 focus:border-white/40 focus:outline-none"
+              placeholder="name@studio.com"
+              autoComplete="email"
+            />
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="w-full rounded-full border border-white/20 bg-white/90 px-4 py-2 text-sm font-semibold text-zinc-900 transition disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isSubmitting ? "Sending…" : "Email me access"}
+            </button>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => handleOAuth("google")}
+                className="flex-1 rounded-full border border-white/20 bg-white/5 px-3 py-2 text-xs font-semibold text-white transition hover:border-white/40"
+              >
+                Continue with Google
+              </button>
+              <button
+                type="button"
+                onClick={() => handleOAuth("github")}
+                className="flex-1 rounded-full border border-white/20 bg-white/5 px-3 py-2 text-xs font-semibold text-white transition hover:border-white/40"
+              >
+                GitHub
+              </button>
+            </div>
+          </form>
+        )}
+
+        {statusMessage ? (
+          <p className="mt-3 text-xs text-emerald-300">{statusMessage}</p>
+        ) : null}
+        {error ? (
+          <p className="mt-3 text-xs text-rose-300">{error}</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/auth/client.ts
+++ b/src/lib/auth/client.ts
@@ -1,0 +1,82 @@
+"use client";
+
+import { createClient, type Session, type SupabaseClient } from "@supabase/supabase-js";
+
+let cachedClient: SupabaseClient | null | undefined;
+
+function resolveSupabaseConfig() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL?.trim();
+  const key =
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY?.trim() ?? process.env.NEXT_PUBLIC_SUPABASE_KEY?.trim();
+  return { url, key };
+}
+
+export function isBrowserSupabaseConfigured(): boolean {
+  const { url, key } = resolveSupabaseConfig();
+  return Boolean(url && key);
+}
+
+export function getSupabaseBrowserClient(): SupabaseClient | null {
+  if (cachedClient !== undefined) {
+    return cachedClient;
+  }
+
+  const { url, key } = resolveSupabaseConfig();
+  if (!url || !key) {
+    cachedClient = null;
+    if (process.env.NODE_ENV !== "production") {
+      console.warn("Supabase browser client is not configured");
+    }
+    return cachedClient;
+  }
+
+  cachedClient = createClient(url, key, {
+    auth: {
+      persistSession: true,
+      detectSessionInUrl: true,
+      storageKey: "script-speech-auth", // custom key for clarity
+      autoRefreshToken: true,
+    },
+    global: {
+      headers: {
+        "X-Client-Info": "script-speech/web",
+      },
+    },
+  });
+
+  return cachedClient;
+}
+
+async function postJson(path: string, payload: Record<string, unknown>) {
+  await fetch(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+    credentials: "include",
+    cache: "no-store",
+  });
+}
+
+async function deleteJson(path: string) {
+  await fetch(path, {
+    method: "DELETE",
+    credentials: "include",
+    cache: "no-store",
+  });
+}
+
+export async function syncSessionCookie(session: Session | null): Promise<void> {
+  try {
+    if (session?.access_token) {
+      await postJson("/api/auth/session", {
+        accessToken: session.access_token,
+        refreshToken: session.refresh_token ?? undefined,
+      });
+      return;
+    }
+
+    await deleteJson("/api/auth/session");
+  } catch (error) {
+    console.warn("Failed to sync session cookie", error);
+  }
+}

--- a/src/lib/auth/server.ts
+++ b/src/lib/auth/server.ts
@@ -4,7 +4,8 @@ import type { User } from "@supabase/supabase-js";
 
 import { getSupabaseServiceClient } from "@/lib/supabase.server";
 
-const ACCESS_TOKEN_COOKIE = "sb-access-token";
+export const ACCESS_TOKEN_COOKIE = "sb-access-token";
+export const REFRESH_TOKEN_COOKIE = "sb-refresh-token";
 const AUTHORIZATION_HEADER = "authorization";
 
 export interface ServerAuthSession {


### PR DESCRIPTION
## Summary
- add a browser Supabase client, a site-wide session control widget, and an auth callback page to drive magic link and OAuth flows directly from the marketing site
- expose a new `/api/auth/session` endpoint plus exported cookie constants so Supabase tokens are synchronized into HTTP-only cookies with audit logs, and document the required `NEXT_PUBLIC` env vars

## Testing
- `npm run lint` *(fails: `next` binary missing because dependencies cannot be installed — `npm install` is blocked with `403 Forbidden` when fetching `@aws-sdk/client-s3`)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691647f1ded08322b8501dc802248fe3)