### PR TITLE
Add tunnel guidance for sharing local dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Voice-first scriptwriting assistant project. The repository now contains a Next.
    ```
 
 2. Visit `http://localhost:3000` to explore the voice-first landing experience (and `/studio` for the product shell).
+   - Need a shareable link for teammates? Once the dev server is running, start a tunnel (for example with `npx ngrok http 3000`)
+     and share the forwarded URL. The tunnel keeps the `/`, `/studio`, and `/admin/marketing` routes available for remote testing.
 3. Wire up optional backends (Supabase, Upstash Redis, OpenAI) using the guidance below, then consult [`docs/architecture.md`](docs/architecture.md) and [`docs/developer-handbook.md`](docs/developer-handbook.md) for deep dives.
 4. Need to share a live preview link? Follow [`docs/preview-and-testing.md`](docs/preview-and-testing.md) for tunnel instructions and common quality checks.
 


### PR DESCRIPTION
## Summary
- add quick tunnel instructions so teammates can access the dev server remotely
- note that the forwarded URL keeps key routes available for testing

## Testing
- not run (documentation-only change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938a181a7688322ab3b3bb4870dde90)